### PR TITLE
build: fix deployment not able to create new github release

### DIFF
--- a/steps/deploy.ts
+++ b/steps/deploy.ts
@@ -51,7 +51,9 @@ await compileBinary({
 await $`sed -i.bak 's/GH_RELEASE_VERSION=".*"/GH_RELEASE_VERSION="${input.nextVersionName}"/' ./action.yml && rm ./action.yml.bak`
 
 // Commit the changes to action.yml
-await $`git add action.yml && git commit -m "Bump version to ${input.nextVersionName}"`.printCommand()
+// Do not throw on error because there is a scenario where we previously made this commit but we failed and retried the deployment.
+// This should only fail if there is no change to commit, which is fine.
+await $`git add action.yml && git commit -m "Bump version to ${input.nextVersionName}"`.printCommand().noThrow()
 
 console.log(`to help with debugging, log the recently created commit including all the file changes made`)
 await $`git show HEAD`.printCommand()
@@ -75,4 +77,4 @@ if (input.testMode) {
 await $`git push`.printCommand()
 
 // Create the GitHub release with the compiled binaries
-await $`${commandToCreateGithubRelease}`.printCommand()
+await $.raw`${commandToCreateGithubRelease}`.printCommand()


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

Latest deployment failed with error `dax not able to find command gh` which is super weird. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

https://github.com/dsherret/dax/issues/318

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->