### PR TITLE
feat: add optional details about the simulated deployment inside of PR

### DIFF
--- a/deploy.ts
+++ b/deploy.ts
@@ -7,6 +7,7 @@ import { PrepareTestModeEnvStep } from "./lib/steps/prepare-testmode-env.ts"
 import { GitHubCommit } from "./lib/github-api.ts"
 import { StepRunner } from "./lib/step-runner.ts"
 import { ConvenienceStep } from "./lib/steps/convenience.ts"
+import { GetLatestReleaseStepOutput } from "./lib/steps/types/output.ts"
 
 export const run = async ({
   convenienceStep,
@@ -24,7 +25,9 @@ export const run = async ({
   deployStep: DeployStep
   environment: Environment
   log: Logger
-}): Promise<{ nextReleaseVersion: string } | undefined> => {
+}): Promise<
+  { nextReleaseVersion: string; commitsSinceLastRelease: GitHubCommit[]; latestRelease: GetLatestReleaseStepOutput | null } | undefined
+> => {
   if (environment.getEventThatTriggeredThisRun() !== "push" && environment.getEventThatTriggeredThisRun() !== "pull_request") {
     log.error(
       `Sorry, you can only trigger this tool from a push or a pull_request. The event that triggered this run was: ${environment.getEventThatTriggeredThisRun()}. Bye bye...`,
@@ -216,5 +219,5 @@ export const run = async ({
 
   await environment.setOutput({ key: "new_release_version", value: nextReleaseVersion })
 
-  return { nextReleaseVersion }
+  return { nextReleaseVersion, commitsSinceLastRelease: listOfCommits, latestRelease: lastRelease }
 }

--- a/index.ts
+++ b/index.ts
@@ -48,9 +48,19 @@ try {
   const newReleaseVersion = runResult?.nextReleaseVersion
 
   if (shouldPostStatusUpdatesOnPullRequest) {
-    const message = newReleaseVersion
+    let message = newReleaseVersion
       ? `...🟩 **${simulatedMergeType}** 🟩 merge method... 🚢 The next version of the project will be: **${newReleaseVersion}**`
       : `...🟩 **${simulatedMergeType}** 🟩 merge method... 🌴 It will not trigger a deployment. No new version will be deployed.`
+
+    message += `\n\n<details>
+<summary>Learn more</summary>
+<br>
+Latest release: ${runResult?.latestRelease?.versionName || "none, this is the first release."}<br>
+Commit of latest release: ${runResult?.latestRelease?.commitSha || "none, this is the first release."}<br>
+<br>
+Commits since last release:<br>
+- ${runResult?.commitsSinceLastRelease.map((commit) => commit.message).join("<br>- ") || "none"}    
+</details>`
 
     await githubApi.postStatusUpdateOnPullRequest({
       message,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,5 +2,5 @@ pre-commit:
   commands:
     deno_fmt:
       run: deno fmt
-      glob: '**/*.ts'
+      glob: '{*.ts,**/*.ts}'
       stage_fixed: true # Stage files that were fixed


### PR DESCRIPTION
This makes it so you don't have to go into the CI logs anymore to verify if the deployment ran as you expected. You can just View all of it from the pull request.
