### PR TITLE
Parse git commits and provide to step scripts as input

### DIFF
--- a/deploy.test.ts
+++ b/deploy.test.ts
@@ -3,8 +3,6 @@ import { afterEach, describe, it } from "@std/testing/bdd"
 import { restore, stub } from "@std/testing/mock"
 import { assertSnapshot } from "@std/testing/snapshot"
 import { run } from "./deploy.ts"
-import { GitHubCommit } from "./lib/github-api.ts"
-import { GitHubCommitFake } from "./lib/github-api.test.ts"
 import { GetCommitsSinceLatestReleaseStep } from "./lib/steps/get-commits-since-latest-release.ts"
 import { DeployStep } from "./lib/steps/deploy.ts"
 import { getLogMock } from "./lib/log.test.ts"
@@ -333,7 +331,7 @@ const setupTestEnvironmentAndRun = async ({
 
   const convenienceStep = mock<ConvenienceStep>()
   when(convenienceStep, "runConvenienceCommands", async () => {
-    return
+    return { gitCommitsAllLocalBranches: {}, gitCommitsCurrentBranch: [] }
   })
 
   const stepRunner = {} as StepRunner

--- a/deploy.test.ts
+++ b/deploy.test.ts
@@ -15,6 +15,8 @@ import { StepRunner } from "./lib/step-runner.ts"
 import { GetLatestReleaseStepOutputFake } from "./lib/steps/types/output.test.ts"
 import { GetLatestReleaseStepOutput } from "./lib/steps/types/output.ts"
 import { ConvenienceStep } from "./lib/steps/convenience.ts"
+import { GitCommit } from "./lib/types/git.ts"
+import { GitCommitFake } from "./lib/types/git.test.ts"
 
 describe("run the tool in different scenarios", () => {
   afterEach(() => {
@@ -32,7 +34,7 @@ describe("run the tool in different scenarios", () => {
 
   it("given no commits trigger a release, expect to not run a new deployment", async () => {
     const { deployStepMock } = await setupTestEnvironmentAndRun({
-      commitsSinceLatestRelease: [new GitHubCommitFake()],
+      commitsSinceLatestRelease: [new GitCommitFake()],
       nextReleaseVersion: undefined,
     })
 
@@ -45,7 +47,7 @@ describe("test github actions output", () => {
   it("should set new release version output when a new release is created", async () => {
     const { setOutputMock } = await setupTestEnvironmentAndRun({
       commitsSinceLatestRelease: [
-        new GitHubCommitFake({
+        new GitCommitFake({
           message: "feat: trigger a release",
           sha: "trigger-release",
         }),
@@ -69,7 +71,7 @@ describe("test github actions output", () => {
   it("should set new pre-release version output when a new pre-release is created", async () => {
     const { setOutputMock } = await setupTestEnvironmentAndRun({
       commitsSinceLatestRelease: [
-        new GitHubCommitFake({
+        new GitCommitFake({
           message: "feat: trigger a release",
           sha: "trigger-release",
         }),
@@ -85,14 +87,14 @@ describe("test github actions output", () => {
   it("should set test mode output when running in test mode", async () => {
     const { setOutputMock } = await setupTestEnvironmentAndRun({
       commitsSinceLatestRelease: [
-        new GitHubCommitFake({
+        new GitCommitFake({
           message: "feat: trigger a release",
           sha: "trigger-release",
         }),
       ],
       nextReleaseVersion: "1.0.0",
       githubActionEventThatTriggeredTool: "pull_request",
-      commitsCreatedBySimulatedMerge: [new GitHubCommitFake()],
+      commitsCreatedBySimulatedMerge: [new GitCommitFake()],
     })
 
     assertEquals(
@@ -101,17 +103,17 @@ describe("test github actions output", () => {
     )
   })
   it("should add commits created during simulated merges to list of commits to analyze", async () => {
-    const givenLatestCommitOnBranch = new GitHubCommitFake({
+    const givenLatestCommitOnBranch = new GitCommitFake({
       message: "feat: trigger a release",
       sha: "trigger-release",
     })
 
     const givenCommitsCreatedBySimulatedMerge = [
-      new GitHubCommitFake({
+      new GitCommitFake({
         message: "Merge commit created during simulated merge",
         sha: "merge-commit-created-during-simulated-merge",
       }),
-      new GitHubCommitFake({
+      new GitCommitFake({
         message: "feat: commit created during simulated merge",
         sha: "commit-created-during-simulated-merge",
       }),
@@ -138,11 +140,11 @@ describe("test github actions output", () => {
   // Test a bug found where you are in test mode > simulate merge > new commits are made > tool says "zero commits created" > exits early.
   it("should not exit early if parent branch has no commits, but we make new commits during simulated merge", async () => {
     const givenCommitsCreatedBySimulatedMerge = [
-      new GitHubCommitFake({
+      new GitCommitFake({
         message: "Merge commit created during simulated merge",
         sha: "merge-commit-created-during-simulated-merge",
       }),
-      new GitHubCommitFake({
+      new GitCommitFake({
         message: "feat: commit created during simulated merge",
         sha: "commit-created-during-simulated-merge",
       }),
@@ -166,7 +168,7 @@ describe("test github actions output", () => {
 describe("user facing logs", () => {
   it("given no commits will trigger a release, expect logs to easily communicate that to the user", async (t) => {
     const { logMock } = await setupTestEnvironmentAndRun({
-      commitsSinceLatestRelease: [new GitHubCommitFake()],
+      commitsSinceLatestRelease: [new GitCommitFake()],
       nextReleaseVersion: undefined,
     })
 
@@ -182,7 +184,7 @@ describe("user facing logs", () => {
   })
 
   it("given no release has ever been made, expect logs to easily communicate that to the user", async (t) => {
-    const givenLatestCommitOnBranch = new GitHubCommitFake({
+    const givenLatestCommitOnBranch = new GitCommitFake({
       message: "feat: trigger a release",
       sha: "trigger-release",
     })
@@ -200,7 +202,7 @@ describe("user facing logs", () => {
     const givenBaseBranch = "sweet-feature"
     const givenTargetBranch = "main"
 
-    const givenLatestCommitOnBranch = new GitHubCommitFake({
+    const givenLatestCommitOnBranch = new GitCommitFake({
       message: "feat: trigger a release",
       sha: "trigger-release",
     })
@@ -231,7 +233,7 @@ describe("test the event that triggered running the tool", () => {
       githubActionEventThatTriggeredTool: "push",
       nextReleaseVersion: "1.0.0",
       commitsSinceLatestRelease: [
-        new GitHubCommitFake({
+        new GitCommitFake({
           message: "feat: trigger a release",
           sha: "trigger-release",
         }),
@@ -252,7 +254,7 @@ describe("test the event that triggered running the tool", () => {
       githubActionEventThatTriggeredTool: "pull_request",
       nextReleaseVersion: "1.0.0",
       commitsSinceLatestRelease: [
-        new GitHubCommitFake({
+        new GitCommitFake({
           message: "feat: trigger a release",
           sha: "trigger-release",
         }),
@@ -278,7 +280,7 @@ describe("deployment verification after deploy", () => {
       latestRelease: { versionName: "1.0.0", commitSha: "sha1" },
       latestReleaseAfterDeploy: { versionName: deployedVersion, commitSha: "sha2" },
       nextReleaseVersion: deployedVersion,
-      commitsSinceLatestRelease: [new GitHubCommitFake()],
+      commitsSinceLatestRelease: [new GitCommitFake()],
     })
 
     assertEquals(
@@ -296,7 +298,7 @@ describe("deployment verification after deploy", () => {
         latestRelease: { versionName: wrongLatestRelease, commitSha: "sha2" },
         latestReleaseAfterDeploy: { versionName: wrongLatestRelease, commitSha: "sha2" },
         nextReleaseVersion: deployedVersion,
-        commitsSinceLatestRelease: [new GitHubCommitFake()],
+        commitsSinceLatestRelease: [new GitCommitFake()],
       })
     })
   })
@@ -314,12 +316,12 @@ const setupTestEnvironmentAndRun = async ({
 }: {
   latestRelease?: GetLatestReleaseStepOutput | null
   latestReleaseAfterDeploy?: GetLatestReleaseStepOutput | null
-  commitsSinceLatestRelease?: GitHubCommit[]
+  commitsSinceLatestRelease?: GitCommit[]
   nextReleaseVersion?: string
   githubActionEventThatTriggeredTool?: "push" | "pull_request" | "other"
   pullRequestTargetBranchName?: string
   currentBranchName?: string
-  commitsCreatedBySimulatedMerge?: GitHubCommit[]
+  commitsCreatedBySimulatedMerge?: GitCommit[]
 }) => {
   // Set some defaults.
   const pullRequestTargetBranch = pullRequestTargetBranchName || "main" // assume we are running a pull_request event that merges into main

--- a/deploy.ts
+++ b/deploy.ts
@@ -77,7 +77,7 @@ export const run = async ({
 
   await environment.setOutput({ key: "test_mode_on", value: runInTestMode.toString() })
 
-  await convenienceStep.runConvenienceCommands()
+  const { gitCommitsAllLocalBranches, gitCommitsCurrentBranch } = await convenienceStep.runConvenienceCommands()
 
   log.notice(
     `👀 I see that the git branch ${currentBranch} is checked out. We will begin the deployment process from the latest commit of this branch.`,
@@ -92,6 +92,8 @@ export const run = async ({
     gitRepoOwner: owner,
     gitRepoName: repo,
     testMode: runInTestMode,
+    gitCommitsCurrentBranch,
+    gitCommitsAllLocalBranches,
   })
 
   log.debug(`Latest release on branch ${currentBranch} is: ${JSON.stringify(lastRelease)}`)
@@ -152,6 +154,8 @@ export const run = async ({
     testMode: runInTestMode,
     gitCommitsSinceLastRelease: listOfCommits,
     lastRelease,
+    gitCommitsAllLocalBranches,
+    gitCommitsCurrentBranch,
   }
 
   const nextReleaseVersion = (await stepRunner.determineNextReleaseVersionStep(determineNextReleaseVersionEnvironment))?.version
@@ -185,6 +189,8 @@ export const run = async ({
     gitRepoOwner: owner,
     gitRepoName: repo,
     testMode: runInTestMode,
+    gitCommitsCurrentBranch,
+    gitCommitsAllLocalBranches,
   })
   log.debug(`Latest release after deploy: ${JSON.stringify(latestReleaseAfterDeploy)}`)
 

--- a/deploy.ts
+++ b/deploy.ts
@@ -8,6 +8,7 @@ import { GitHubCommit } from "./lib/github-api.ts"
 import { StepRunner } from "./lib/step-runner.ts"
 import { ConvenienceStep } from "./lib/steps/convenience.ts"
 import { GetLatestReleaseStepOutput } from "./lib/steps/types/output.ts"
+import { GitCommit } from "./lib/types/git.ts"
 
 export const run = async ({
   convenienceStep,
@@ -51,7 +52,7 @@ export const run = async ({
 
   const pullRequestInfo = environment.isRunningInPullRequest()
   const runInTestMode = pullRequestInfo !== undefined
-  let commitsCreatedDuringSimulatedMerges: GitHubCommit[] = []
+  let commitsCreatedDuringSimulatedMerges: GitCommit[] = []
   if (runInTestMode) {
     log.notice(
       `🧪 I see that I got triggered to run from a pull request event. In pull requests, I run in test mode which means that I will run the deployment process but I will not actually deploy anything.`,

--- a/index.ts
+++ b/index.ts
@@ -37,10 +37,10 @@ If this pull request and all of it's parent pull requests are merged using the..
 
 try {
   const runResult = await run({
-    convenienceStep: new ConvenienceStepImpl(exec, environment, logger),
+    convenienceStep: new ConvenienceStepImpl(exec, environment, git, logger),
     stepRunner: new StepRunnerImpl(environment, exec, logger),
     prepareEnvironmentForTestMode: new PrepareTestModeEnvStepImpl(githubApi, environment, new SimulateMergeImpl(git, exec), git, exec),
-    getCommitsSinceLatestReleaseStep: new GetCommitsSinceLatestReleaseStepImpl(githubApi),
+    getCommitsSinceLatestReleaseStep: new GetCommitsSinceLatestReleaseStepImpl(git, exec),
     deployStep: new DeployStepImpl(exec),
     log: logger,
     environment,

--- a/lib/__snapshots__/simulate-merge.test.ts.snap
+++ b/lib/__snapshots__/simulate-merge.test.ts.snap
@@ -2,7 +2,7 @@ export const snapshot = {};
 
 snapshot[`snapshot test all of the merge options > merge, should generate the correct git commands, should end on target branch 1`] = `
 [
-  'git log -1 --pretty=format:"%H|%s|%ci" main',
+  'git log --pretty=format:"||%H|%s|%B|%an|%ae|%cn|%ce|%ci|%P|%D" --numstat main',
   "git checkout feature",
   "git branch --show-current",
   "git pull origin success",
@@ -13,13 +13,14 @@ snapshot[`snapshot test all of the merge options > merge, should generate the co
   'git config user.email "test@test.com"',
   "git checkout main",
   'git merge feature -m "Merge pull request #123 from feature" -m "" --no-ff',
-  'git log --pretty=format:"%H|%s|%ci" success..HEAD',
+  "git branch --show-current",
+  'git log --pretty=format:"||%H|%s|%B|%an|%ae|%cn|%ce|%ci|%P|%D" --numstat success',
 ]
 `;
 
 snapshot[`snapshot test all of the merge options > squash, should generate the correct git commands, should end on target branch 1`] = `
 [
-  'git log -1 --pretty=format:"%H|%s|%ci" main',
+  'git log --pretty=format:"||%H|%s|%B|%an|%ae|%cn|%ce|%ci|%P|%D" --numstat main',
   "git checkout feature",
   "git branch --show-current",
   "git pull origin success",
@@ -35,13 +36,14 @@ snapshot[`snapshot test all of the merge options > squash, should generate the c
   'git commit -m "title-here" -m "message-here"',
   "git checkout main",
   'git merge feature -m "title-here" -m "message-here" --ff-only',
-  'git log --pretty=format:"%H|%s|%ci" success..HEAD',
+  "git branch --show-current",
+  'git log --pretty=format:"||%H|%s|%B|%an|%ae|%cn|%ce|%ci|%P|%D" --numstat success',
 ]
 `;
 
 snapshot[`snapshot test all of the merge options > rebase, should generate the correct git commands, should end on target branch 1`] = `
 [
-  'git log -1 --pretty=format:"%H|%s|%ci" main',
+  'git log --pretty=format:"||%H|%s|%B|%an|%ae|%cn|%ce|%ci|%P|%D" --numstat main',
   "git checkout feature",
   "git branch --show-current",
   "git pull origin success",
@@ -54,6 +56,7 @@ snapshot[`snapshot test all of the merge options > rebase, should generate the c
   "git rebase main",
   "git checkout main",
   'git merge feature -m "title-here" -m "message-here" --ff-only',
-  'git log --pretty=format:"%H|%s|%ci" success..HEAD',
+  "git branch --show-current",
+  'git log --pretty=format:"||%H|%s|%B|%an|%ae|%cn|%ce|%ci|%P|%D" --numstat success',
 ]
 `;

--- a/lib/exec.test.ts
+++ b/lib/exec.test.ts
@@ -1,6 +1,7 @@
 import { exec } from "./exec.ts"
 import { assertEquals } from "@std/assert"
 import { DeployStepInput } from "./types/environment.ts"
+import { GitCommitFake } from "./types/git.test.ts"
 
 const givenPluginInput: DeployStepInput = {
   gitCurrentBranch: "main",
@@ -10,6 +11,17 @@ const givenPluginInput: DeployStepInput = {
   nextVersionName: "1.0.0",
   testMode: true,
   lastRelease: null,
+  gitCommitsAllLocalBranches: {
+    "branch-1": [
+      new GitCommitFake({}),
+    ],
+    "branch-2": [
+      new GitCommitFake({}),
+    ],
+  },
+  gitCommitsCurrentBranch: [
+    new GitCommitFake({}),
+  ],
 }
 
 Deno.test("given contextual input data, expect the executed command receives the input data", async () => {

--- a/lib/git.test.ts
+++ b/lib/git.test.ts
@@ -110,6 +110,7 @@ This is a merge commit with multiple parents.|John Doe|john@example.com|GitHub|n
   assertEquals(result.length, 1)
   assertFirstCommit(result, {
     sha: "abc1234567890123456789012345678901234567",
+    abbreviatedSha: "abc12345",
     title: "Merge pull request #123 from feature/new-feature",
     isMergeCommit: true,
     isRevertCommit: false,
@@ -120,6 +121,23 @@ This is a merge commit with multiple parents.|John Doe|john@example.com|GitHub|n
       { filename: "src/file1.ts", additions: 5, deletions: 2 },
       { filename: "src/file2.ts", additions: 10, deletions: 0 },
     ],
+  })
+})
+
+Deno.test("getCommits - should parse abbreviated SHA correctly", async () => {
+  const gitLogOutput = `||abc1234567890123456789012345678901234567|feat: test abbreviated SHA|feat: test abbreviated SHA
+
+Testing that abbreviated SHA is correctly extracted.|Test Author|test@example.com|Test Author|test@example.com|2023-10-15T10:30:00Z|parent1|main
+1	0	test.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    sha: "abc1234567890123456789012345678901234567",
+    abbreviatedSha: "abc12345",
+    title: "feat: test abbreviated SHA",
   })
 })
 
@@ -136,6 +154,8 @@ The feature was causing issues in production.|Alice Smith|alice@example.com|Alic
 
   assertEquals(result.length, 1)
   assertFirstCommit(result, {
+    sha: "def9876543210987654321098765432109876543",
+    abbreviatedSha: "def98765",
     isRevertCommit: true,
     isMergeCommit: false,
     title: 'Revert "Add problematic feature"',

--- a/lib/git.test.ts
+++ b/lib/git.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from "@std/testing/bdd"
 import { assertSpyCall, restore, stub } from "@std/testing/mock"
 import { exec } from "./exec.ts"
 import { git } from "./git.ts"
+import { GitCommit } from "./types/git.ts"
 
 describe("checkoutBranch", () => {
   afterEach(() => {
@@ -74,5 +75,342 @@ describe("createLocalBranchFromRemote", () => {
     assertRejects(async () => {
       await git.createLocalBranchFromRemote({ exec, branch: "main" })
     }, Error)
+  })
+})
+
+const setupExecMock = (stdout: string) => {
+  restore() // Reset any existing mocks before creating a new one
+  stub(exec, "run", async (args) => {
+    return { exitCode: 0, stdout, output: undefined }
+  })
+}
+
+const assertCommit = (commit: GitCommit, expected: Partial<GitCommit>) => {
+  for (const [key, value] of Object.entries(expected)) {
+    assertEquals(commit[key as keyof GitCommit], value, `Expected ${key} to match`)
+  }
+}
+
+const assertFirstCommit = (result: GitCommit[], expected: Partial<GitCommit>) => {
+  assertEquals(result.length >= 1, true, "Expected at least one commit")
+  assertCommit(result[0], expected)
+}
+
+Deno.test("getCommits - should parse merge commits", async () => {
+  const gitLogOutput =
+    `||abc1234567890123456789012345678901234567|Merge pull request #123 from feature/new-feature|Merge pull request #123 from feature/new-feature
+
+This is a merge commit with multiple parents.|John Doe|john@example.com|GitHub|noreply@github.com|2023-10-15T10:30:00Z|parent1 parent2|HEAD -> main, origin/main
+5	2	src/file1.ts
+10	0	src/file2.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    sha: "abc1234567890123456789012345678901234567",
+    title: "Merge pull request #123 from feature/new-feature",
+    isMergeCommit: true,
+    isRevertCommit: false,
+    parents: ["parent1", "parent2"],
+    filesChanged: ["src/file1.ts", "src/file2.ts"],
+    stats: { additions: 15, deletions: 2, total: 17 },
+    fileStats: [
+      { filename: "src/file1.ts", additions: 5, deletions: 2 },
+      { filename: "src/file2.ts", additions: 10, deletions: 0 },
+    ],
+  })
+})
+
+Deno.test("getCommits - should parse revert commits", async () => {
+  const gitLogOutput = `||def9876543210987654321098765432109876543|Revert "Add problematic feature"|Revert "Add problematic feature"
+
+This reverts commit abc123.
+
+The feature was causing issues in production.|Alice Smith|alice@example.com|Alice Smith|alice@example.com|2023-10-14T15:20:00Z|parent1|main
+3	5	src/feature.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    isRevertCommit: true,
+    isMergeCommit: false,
+    title: 'Revert "Add problematic feature"',
+    parents: ["parent1"],
+    stats: { additions: 3, deletions: 5, total: 8 },
+  })
+})
+
+Deno.test("getCommits - should parse commits with no file stats", async () => {
+  const gitLogOutput = `||xyz1111111111111111111111111111111111111|Initial commit|Initial commit
+
+This is the very first commit with no files changed.|Bob Wilson|bob@example.com|Bob Wilson|bob@example.com|2023-10-01T09:00:00Z| |main`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    filesChanged: [],
+    stats: { additions: 0, deletions: 0, total: 0 },
+    fileStats: [],
+    parents: [],
+    branch: "main",
+  })
+})
+
+Deno.test("getCommits - should parse file stats with multiple files", async () => {
+  const gitLogOutput = `||mno4444444444444444444444444444444444444|feat: implement user authentication|feat: implement user authentication
+
+Added login, logout, and session management.
+Includes unit tests and documentation.|Carol Davis|carol@example.com|Carol Davis|carol@example.com|2023-10-12T14:45:00Z|parent1|origin/main, main
+25	0	src/auth/login.ts
+15	3	src/auth/session.ts
+40	0	tests/auth.test.ts
+5	1	README.md
+-	-	assets/logo.png`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    filesChanged: ["src/auth/login.ts", "src/auth/session.ts", "tests/auth.test.ts", "README.md", "assets/logo.png"],
+    stats: { additions: 85, deletions: 4, total: 89 },
+    fileStats: [
+      { filename: "src/auth/login.ts", additions: 25, deletions: 0 },
+      { filename: "src/auth/session.ts", additions: 15, deletions: 3 },
+      { filename: "tests/auth.test.ts", additions: 40, deletions: 0 },
+      { filename: "README.md", additions: 5, deletions: 1 },
+      { filename: "assets/logo.png", additions: 0, deletions: 0 },
+    ],
+  })
+})
+
+Deno.test("getCommits - should parse commits with tags", async () => {
+  const gitLogOutput = `||tag1111111111111111111111111111111111111|v2.1.0 release|v2.1.0 release
+
+Release version 2.1.0 with new features and bug fixes.|Release Bot|release@example.com|Release Bot|release@example.com|2023-10-20T12:00:00Z|parent1|tag: v2.1.0, tag: v2.1.0-rc1, main
+2	1	package.json
+10	5	CHANGELOG.md`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    tags: ["v2.1.0", "v2.1.0-rc1"],
+    branch: "main",
+    refs: ["tag: v2.1.0", "tag: v2.1.0-rc1", "main"],
+  })
+})
+
+Deno.test("getCommits - should parse commits with empty refs", async () => {
+  const gitLogOutput = `||empty111111111111111111111111111111111111|fix: minor bug fix|fix: minor bug fix
+
+Fixed a small issue in error handling.|Dev User|dev@example.com|Dev User|dev@example.com|2023-10-18T08:15:00Z|parent1|
+1	1	src/error.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    refs: [],
+    tags: [],
+    branch: undefined,
+  })
+})
+
+Deno.test("getCommits - should parse multiple commits", async () => {
+  const gitLogOutput = `||commit1111111111111111111111111111111111111|feat: add search functionality|feat: add search functionality
+
+Implemented full-text search with indexing.|Alice Dev|alice@dev.com|Alice Dev|alice@dev.com|2023-10-25T16:30:00Z|parent1|main
+50	10	src/search.ts
+25	5	src/index.ts
+||commit2222222222222222222222222222222222222|fix: resolve memory leak|fix: resolve memory leak
+
+Fixed memory leak in event listeners.|Bob Dev|bob@dev.com|Bob Dev|bob@dev.com|2023-10-24T14:20:00Z|parent2|main
+5	15	src/events.ts
+3	0	src/cleanup.ts
+||commit3333333333333333333333333333333333333|Merge pull request #456 from feature/auth|Merge pull request #456 from feature/auth
+
+Merge authentication feature branch.|GitHub|noreply@github.com|GitHub|noreply@github.com|2023-10-23T12:00:00Z|merge1 merge2|HEAD -> main, origin/main
+0	0	merge-file.txt
+||commit4444444444444444444444444444444444444|Revert "Broken feature"|Revert "Broken feature"
+
+This reverts commit broken123.|Carol Maintainer|carol@example.com|Carol Maintainer|carol@example.com|2023-10-22T09:15:00Z|parent4|tag: v1.2.0, main
+10	20	src/revert.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 4)
+
+  // First commit - regular feature commit
+  assertCommit(result[0], {
+    sha: "commit1111111111111111111111111111111111111",
+    title: "feat: add search functionality",
+    author: { name: "Alice Dev", email: "alice@dev.com" },
+    stats: { additions: 75, deletions: 15, total: 90 },
+    isMergeCommit: false,
+    isRevertCommit: false,
+    filesChanged: ["src/search.ts", "src/index.ts"],
+  })
+
+  // Second commit - bug fix
+  assertCommit(result[1], {
+    sha: "commit2222222222222222222222222222222222222",
+    title: "fix: resolve memory leak",
+    author: { name: "Bob Dev", email: "bob@dev.com" },
+    stats: { additions: 8, deletions: 15, total: 23 },
+    isMergeCommit: false,
+    isRevertCommit: false,
+    parents: ["parent2"],
+  })
+
+  // Third commit - merge commit
+  assertCommit(result[2], {
+    sha: "commit3333333333333333333333333333333333333",
+    title: "Merge pull request #456 from feature/auth",
+    isMergeCommit: true,
+    isRevertCommit: false,
+    parents: ["merge1", "merge2"],
+    refs: ["HEAD -> main", "origin/main"],
+  })
+
+  // Fourth commit - revert commit with tag
+  assertCommit(result[3], {
+    sha: "commit4444444444444444444444444444444444444",
+    title: 'Revert "Broken feature"',
+    isRevertCommit: true,
+    isMergeCommit: false,
+    tags: ["v1.2.0"],
+    stats: { additions: 10, deletions: 20, total: 30 },
+  })
+})
+
+Deno.test("getCommits - should handle binary files correctly", async () => {
+  const gitLogOutput = `||binary11111111111111111111111111111111111|docs: add documentation images|docs: add documentation images
+
+Added screenshots and diagrams for documentation.|Doc Writer|docs@example.com|Doc Writer|docs@example.com|2023-10-22T11:45:00Z|parent1|main
+-	-	docs/screenshot1.png
+-	-	docs/diagram.jpg
+20	5	docs/setup.md
+15	0	docs/usage.md`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    filesChanged: ["docs/screenshot1.png", "docs/diagram.jpg", "docs/setup.md", "docs/usage.md"],
+    stats: { additions: 35, deletions: 5, total: 40 },
+    fileStats: [
+      { filename: "docs/screenshot1.png", additions: 0, deletions: 0 },
+      { filename: "docs/diagram.jpg", additions: 0, deletions: 0 },
+      { filename: "docs/setup.md", additions: 20, deletions: 5 },
+      { filename: "docs/usage.md", additions: 15, deletions: 0 },
+    ],
+  })
+})
+
+Deno.test("getCommits - should parse commit with complex message", async () => {
+  const gitLogOutput =
+    `||complex111111111111111111111111111111111|refactor: restructure authentication module|refactor: restructure authentication module
+
+This commit includes several changes:
+- Moved auth logic to separate files
+- Added better error handling
+- Improved type safety
+- Updated tests
+
+Breaking changes:
+- AuthService interface has changed
+- Login method now returns Promise<User>
+
+Fixes #123, #456
+Co-authored-by: Jane Doe <jane@example.com>|Main Author|main@example.com|Main Author|main@example.com|2023-10-23T09:30:00Z|parent1|origin/feature-auth, feature-auth
+30	45	src/auth/service.ts
+20	10	src/auth/types.ts
+15	5	tests/auth.test.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    title: "refactor: restructure authentication module",
+    branch: "feature-auth",
+    refs: ["origin/feature-auth", "feature-auth"],
+  })
+  assertEquals(result[0].messageLines.length, 14) // Multiple lines in the message
+  assertEquals(result[0].messageLines[0], "refactor: restructure authentication module")
+  assertEquals(result[0].messageLines[1], "")
+  assertEquals(result[0].messageLines[2], "This commit includes several changes:")
+})
+
+Deno.test("getCommits - should handle commits with HEAD reference", async () => {
+  const gitLogOutput = `||head1111111111111111111111111111111111111|chore: update dependencies|chore: update dependencies
+
+Updated all packages to latest versions.|Maintainer|maintainer@example.com|Maintainer|maintainer@example.com|2023-10-26T10:00:00Z|parent1|HEAD -> main, origin/main
+5	3	package.json
+100	50	package-lock.json`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    refs: ["HEAD -> main", "origin/main"],
+    branch: "origin/main", // Should pick the first non-HEAD, non-tag ref
+  })
+})
+
+Deno.test("getCommits - should return empty array for no commits", async () => {
+  setupExecMock("")
+  const result = await git.getCommits({ exec, branch: "empty-branch" })
+  assertEquals(result, [])
+})
+
+Deno.test("getCommits - should handle commits with only deletions", async () => {
+  const gitLogOutput = `||delete11111111111111111111111111111111111|remove: delete unused files|remove: delete unused files
+
+Cleanup: removed old, unused files.|Cleaner|clean@example.com|Cleaner|clean@example.com|2023-10-27T13:15:00Z|parent1|main
+0	50	old-file1.ts
+0	25	old-file2.ts
+0	10	deprecated.md`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    stats: { additions: 0, deletions: 85, total: 85 },
+    fileStats: [
+      { filename: "old-file1.ts", additions: 0, deletions: 50 },
+      { filename: "old-file2.ts", additions: 0, deletions: 25 },
+      { filename: "deprecated.md", additions: 0, deletions: 10 },
+    ],
+  })
+})
+
+Deno.test("getCommits - should parse dates correctly", async () => {
+  const gitLogOutput = `||date1111111111111111111111111111111111111|test: verify date parsing|test: verify date parsing
+
+Testing date parsing functionality.|Date Tester|date@example.com|Date Tester|date@example.com|2023-12-25T23:59:59Z|parent1|main
+1	0	test.ts`
+
+  setupExecMock(gitLogOutput)
+  const result = await git.getCommits({ exec, branch: "main" })
+
+  assertEquals(result.length, 1)
+  assertFirstCommit(result, {
+    date: new Date("2023-12-25T23:59:59Z"),
+    author: { name: "Date Tester", email: "date@example.com" },
+    committer: { name: "Date Tester", email: "date@example.com" },
   })
 })

--- a/lib/git.test.ts
+++ b/lib/git.test.ts
@@ -414,3 +414,43 @@ Testing date parsing functionality.|Date Tester|date@example.com|Date Tester|dat
     committer: { name: "Date Tester", email: "date@example.com" },
   })
 })
+
+Deno.test("getCurrentBranch - should return the current branch name", async () => {
+  setupExecMock("feature-branch")
+
+  const result = await git.getCurrentBranch({ exec })
+
+  assertEquals(result, "feature-branch")
+})
+
+Deno.test("getCurrentBranch - should handle whitespace in branch name", async () => {
+  setupExecMock("  develop  \n")
+
+  const result = await git.getCurrentBranch({ exec })
+
+  assertEquals(result, "develop")
+})
+
+Deno.test("getLocalBranches - should return list of local branches", async () => {
+  setupExecMock("main\nfeature-branch\ndevelop")
+
+  const result = await git.getLocalBranches({ exec })
+
+  assertEquals(result, ["main", "feature-branch", "develop"])
+})
+
+Deno.test("getLocalBranches - should handle single branch", async () => {
+  setupExecMock("main")
+
+  const result = await git.getLocalBranches({ exec })
+
+  assertEquals(result, ["main"])
+})
+
+Deno.test("getLocalBranches - should handle empty repository with no branches", async () => {
+  setupExecMock("")
+
+  const result = await git.getLocalBranches({ exec })
+
+  assertEquals(result, [])
+})

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -304,6 +304,7 @@ const getCommits = async (
     return {
       title: title.trim(),
       sha: sha.trim(),
+      abbreviatedSha: sha.trim().substring(0, 8),
       message: message.trim(),
       messageLines: message.trim().split("\n"),
       author: { name: authorName.trim(), email: authorEmail.trim() },

--- a/lib/simulate-merge.test.ts
+++ b/lib/simulate-merge.test.ts
@@ -18,6 +18,19 @@ describe("snapshot test all of the merge options", () => {
         return { exitCode: 0, stdout: "3", output: undefined }
       }
 
+      // log expects to return a list of commits
+      // I am not the biggest fan of having to do this (I would prefer to mock the git module functions directly), but because we need to capture the git commands being executed, we have to put these mocks here.
+      if (args.command.includes("git log")) {
+        return {
+          exitCode: 0,
+          stdout:
+            `||f15d5ac43a47b8333019461170fcaf0bd5a139d4|test: update snapshots to remove un-used ones|test: update snapshots to remove un-used ones
+|Foo Bar|foo@bar.com|Foo Bar|foo@bar.com|2025-07-09 07:02:35 -0500|2c7e53b35e1b4b278700294b7781d770f16124c8|
+0       42      __snapshots__/deploy.test.ts.snap`,
+          output: undefined,
+        }
+      }
+
       return { exitCode: 0, stdout: "success", output: undefined }
     })
     simulateMerge = new SimulateMergeImpl(git, exec)

--- a/lib/simulate-merge.ts
+++ b/lib/simulate-merge.ts
@@ -1,6 +1,7 @@
 import { Exec } from "./exec.ts"
 import { Git } from "./git.ts"
 import { GitHubCommit } from "./github-api.ts"
+import { GitCommit } from "./types/git.ts"
 
 export interface SimulateMerge {
   performSimulation(
@@ -12,7 +13,7 @@ export interface SimulateMerge {
       pullRequestTitle: string
       pullRequestDescription: string
     },
-  ): Promise<GitHubCommit[]>
+  ): Promise<GitCommit[]>
   merge: (
     { baseBranch, targetBranch, commitTitle, commitMessage }: {
       baseBranch: string
@@ -20,7 +21,7 @@ export interface SimulateMerge {
       commitTitle: string
       commitMessage: string
     },
-  ) => Promise<GitHubCommit[]>
+  ) => Promise<GitCommit[]>
   squash: (
     { baseBranch, targetBranch, commitTitle, commitMessage }: {
       baseBranch: string
@@ -28,7 +29,7 @@ export interface SimulateMerge {
       commitTitle: string
       commitMessage: string
     },
-  ) => Promise<GitHubCommit[]>
+  ) => Promise<GitCommit[]>
   rebase: (
     { baseBranch, targetBranch, commitTitle, commitMessage }: {
       baseBranch: string
@@ -36,7 +37,7 @@ export interface SimulateMerge {
       commitTitle: string
       commitMessage: string
     },
-  ) => Promise<GitHubCommit[]>
+  ) => Promise<GitCommit[]>
 }
 
 export class SimulateMergeImpl implements SimulateMerge {

--- a/lib/steps/deploy.test.ts
+++ b/lib/steps/deploy.test.ts
@@ -13,6 +13,8 @@ const defaultEnvironment: DeployStepInput = {
   nextVersionName: "1.0.0",
   testMode: true,
   lastRelease: null,
+  gitCommitsAllLocalBranches: {},
+  gitCommitsCurrentBranch: [],
 }
 
 describe("run the user given deploy commands", () => {

--- a/lib/steps/deploy.ts
+++ b/lib/steps/deploy.ts
@@ -40,13 +40,12 @@ export class DeployStepImpl implements DeployStep {
       : undefined
 
     if (deployCommand) {
-      const { exitCode, output: outputRecord } = await this.exec.run({
+      const { exitCode } = await this.exec.run({
         command: deployCommand,
         input: environment,
         displayLogs: true,
         throwOnNonZeroExitCode: false,
       })
-      // const output: DeployCommandOutput | undefined = isDeployCommandOutput(outputRecord) ? outputRecord : undefined
 
       if (exitCode !== 0) {
         log.error(

--- a/lib/steps/get-commits-since-latest-release.ts
+++ b/lib/steps/get-commits-since-latest-release.ts
@@ -1,4 +1,7 @@
-import { GitHubApi, GitHubCommit } from "../github-api.ts"
+import { Exec, exec } from "../exec.ts"
+import { Git } from "../git.ts"
+import { GitHubApi } from "../github-api.ts"
+import { GitCommit } from "../types/git.ts"
 import { GetLatestReleaseStepOutput } from "./types/output.ts"
 
 export interface GetCommitsSinceLatestReleaseStep {
@@ -7,37 +10,33 @@ export interface GetCommitsSinceLatestReleaseStep {
     repo: string
     branch: string
     latestRelease: GetLatestReleaseStepOutput | null
-  }): Promise<GitHubCommit[]>
+  }): Promise<GitCommit[]>
 }
 
 export class GetCommitsSinceLatestReleaseStepImpl implements GetCommitsSinceLatestReleaseStep {
-  constructor(private githubApi: GitHubApi) {}
+  constructor(private git: Git, private exec: Exec) {}
 
   async getAllCommitsSinceGivenCommit({ owner, repo, branch, latestRelease }: {
     owner: string
     repo: string
     branch: string
     latestRelease: GetLatestReleaseStepOutput | null
-  }): Promise<GitHubCommit[]> {
-    let returnResult: GitHubCommit[] = []
+  }): Promise<GitCommit[]> {
+    let returnResult: GitCommit[] = []
 
-    await this.githubApi.getCommitsForBranch({
-      owner,
-      repo,
+    const commits = await this.git.getCommits({
+      exec: this.exec,
       branch,
-      processCommits: async (commits) => {
-        for (const commit of commits) {
-          // We do not want to include the last tag commit in the list of commits. This may result in making a release from this commit which we do not want.
-          if (commit.sha === latestRelease?.commitSha) {
-            return false // stop paging when we reach the last tag commit
-          }
-
-          returnResult.push(commit)
-        }
-
-        return true // continue paging
-      },
     })
+
+    for (const commit of commits) {
+      // We do not want to include the last tag commit in the list of commits. This may result in making a release from this commit which we do not want.
+      if (commit.sha === latestRelease?.commitSha) {
+        break
+      }
+
+      returnResult.push(commit)
+    }
 
     // sort commits by date. first commit is the newest one
     returnResult.sort((a, b) => b.date.getTime() - a.date.getTime())

--- a/lib/steps/prepare-testmode-env.test.ts
+++ b/lib/steps/prepare-testmode-env.test.ts
@@ -8,6 +8,7 @@ import { mock, when } from "../mock/mock.ts"
 import { GitHubCommitFake } from "../github-api.test.ts"
 import { Git } from "../git.ts"
 import { Exec } from "../exec.ts"
+import { GitCommitFake } from "../types/git.test.ts"
 
 describe("prepareEnvironmentForTestMode", () => {
   let step: PrepareTestModeEnvStepImpl
@@ -77,13 +78,13 @@ describe("prepareEnvironmentForTestMode", () => {
     ])
 
     const expectedCommitsCreatedByFirstSimulatedMerge = [
-      new GitHubCommitFake({ sha: "merge commit for merging feature-branch-2 into feature-branch-1" }),
-      new GitHubCommitFake({ sha: "super sweet feature in feature-branch-2" }),
+      new GitCommitFake({ sha: "merge commit for merging feature-branch-2 into feature-branch-1" }),
+      new GitCommitFake({ sha: "super sweet feature in feature-branch-2" }),
     ]
 
     const expectedCommitsCreatedBySecondSimulatedMerge = [
-      new GitHubCommitFake({ sha: "merge commit for merging feature-branch-1 into main" }),
-      new GitHubCommitFake({ sha: "super sweet feature in feature-branch-1" }),
+      new GitCommitFake({ sha: "merge commit for merging feature-branch-1 into main" }),
+      new GitCommitFake({ sha: "super sweet feature in feature-branch-1" }),
     ]
 
     const expectedCommitsCreatedBySimulatedMerge = [

--- a/lib/steps/prepare-testmode-env.ts
+++ b/lib/steps/prepare-testmode-env.ts
@@ -4,12 +4,13 @@ import { Environment } from "../environment.ts"
 import { GitHubApi, GitHubCommit } from "../github-api.ts"
 import { logger } from "../log.ts"
 import { SimulateMerge } from "../simulate-merge.ts"
+import { GitCommit } from "../types/git.ts"
 
 export interface PrepareTestModeEnvStep {
   prepareEnvironmentForTestMode({ owner, repo }: {
     owner: string
     repo: string
-  }): Promise<{ currentGitBranch: string; commitsCreatedDuringSimulatedMerges: GitHubCommit[] } | undefined>
+  }): Promise<{ currentGitBranch: string; commitsCreatedDuringSimulatedMerges: GitCommit[] } | undefined>
 }
 
 export class PrepareTestModeEnvStepImpl implements PrepareTestModeEnvStep {
@@ -24,7 +25,7 @@ export class PrepareTestModeEnvStepImpl implements PrepareTestModeEnvStep {
   prepareEnvironmentForTestMode = async ({ owner, repo }: {
     owner: string
     repo: string
-  }): Promise<{ currentGitBranch: string; commitsCreatedDuringSimulatedMerges: GitHubCommit[] } | undefined> => {
+  }): Promise<{ currentGitBranch: string; commitsCreatedDuringSimulatedMerges: GitCommit[] } | undefined> => {
     const testModeContext = this.environment.isRunningInPullRequest()
     const runInTestMode = testModeContext !== undefined
 
@@ -34,7 +35,7 @@ export class PrepareTestModeEnvStepImpl implements PrepareTestModeEnvStep {
     logger.debug(`Simulated merge type: ${simulateMergeType}`)
 
     const pullRequestStack = await this.githubApi.getPullRequestStack({ owner, repo, startingPrNumber: testModeContext.prNumber })
-    const commitsCreatedDuringSimulatedMerges: GitHubCommit[] = []
+    const commitsCreatedDuringSimulatedMerges: GitCommit[] = []
     let currentBranch: string = "" // will be set to the last target branch after all simulated merges are done.
 
     for await (const pr of pullRequestStack) {

--- a/lib/steps/types/output.test.ts
+++ b/lib/steps/types/output.test.ts
@@ -1,9 +1,18 @@
-import { GetLatestReleaseStepOutput, isGetLatestReleaseStepOutput } from "./output.ts"
+import {
+  GetLatestReleaseStepOutput,
+  GetNextReleaseVersionStepOutput,
+  isGetLatestReleaseStepOutput,
+  isGetNextReleaseVersionStepOutput,
+} from "./output.ts"
 import { assert, assertFalse } from "@std/assert"
 
 export const GetLatestReleaseStepOutputFake: GetLatestReleaseStepOutput = {
   versionName: "v1.0.0",
   commitSha: "abc123",
+}
+
+export const GetNextReleaseVersionStepOutputFake: GetNextReleaseVersionStepOutput = {
+  version: "2.1.0",
 }
 
 // isGetLatestReleaseStepOutput
@@ -44,4 +53,79 @@ Deno.test("isGetLatestReleaseStepOutput - given array input, expect false", () =
 
 Deno.test("isGetLatestReleaseStepOutput - given object with extra properties, expect true", () => {
   assert(isGetLatestReleaseStepOutput({ versionName: "v1.2.3", commitSha: "xyz789", extra: 42 }))
+})
+
+// isGetNextReleaseVersionStepOutput
+Deno.test("isGetNextReleaseVersionStepOutput - given empty object, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput({}))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given valid object, expect true", () => {
+  assert(isGetNextReleaseVersionStepOutput({
+    version: "2.1.3",
+  }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object missing version, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput({ otherProperty: "value" }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with wrong version type, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput({ version: 123 }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with version as object, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput({ version: { major: 1, minor: 2, patch: 3 } }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with version as array, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput({ version: ["1", "2", "3"] }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with version as boolean, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput({ version: true }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given null input, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput(null))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given undefined input, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput(undefined))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given array input, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput([]))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given string input, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput("1.2.3"))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given number input, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput(123))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given boolean input, expect false", () => {
+  assertFalse(isGetNextReleaseVersionStepOutput(true))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with extra properties, expect true", () => {
+  assert(isGetNextReleaseVersionStepOutput({
+    version: "1.2.3",
+    extra: 42,
+    anotherProperty: "value",
+  }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with empty version string, expect true", () => {
+  assert(isGetNextReleaseVersionStepOutput({ version: "" }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with semantic version, expect true", () => {
+  assert(isGetNextReleaseVersionStepOutput({ version: "1.2.3-alpha.1+build.123" }))
+})
+
+Deno.test("isGetNextReleaseVersionStepOutput - given object with version containing whitespace, expect true", () => {
+  assert(isGetNextReleaseVersionStepOutput({ version: "  1.2.3  " }))
 })

--- a/lib/steps/types/output.ts
+++ b/lib/steps/types/output.ts
@@ -1,18 +1,6 @@
 // Purposely making properties optional for convenience.
-export interface DeployCommandOutput {
-  filesToCommit?: string[]
-}
-
-// deno-lint-ignore no-explicit-any
-export const isDeployCommandOutput = (obj: any): obj is DeployCommandOutput => {
-  return (
-    obj &&
-    (obj.filesToCommit === undefined ||
-      (Array.isArray(obj.filesToCommit) &&
-        // deno-lint-ignore no-explicit-any
-        obj.filesToCommit.every((item: any) => typeof item === "string")))
-  )
-}
+// deno-lint-ignore no-empty-interface
+export interface DeployCommandOutput {}
 
 export interface GetLatestReleaseStepOutput {
   versionName: string

--- a/lib/types/environment.ts
+++ b/lib/types/environment.ts
@@ -1,5 +1,5 @@
-import { GitHubCommit } from "../github-api.ts"
 import { GetLatestReleaseStepOutput } from "../steps/types/output.ts"
+import { GitCommit } from "./git.ts"
 
 /*
   Each environment object contains information about the current state of the git repository and data that the tool has fetched/processed. Each step of the deployment may find this environment object useful to make decisions on what to do next.
@@ -16,7 +16,7 @@ export interface GetLatestReleaseStepInput {
 
 export interface GetNextReleaseVersionStepInput extends GetLatestReleaseStepInput {
   lastRelease: GetLatestReleaseStepOutput | null
-  gitCommitsSinceLastRelease: GitHubCommit[]
+  gitCommitsSinceLastRelease: GitCommit[]
 }
 
 export interface DeployStepInput extends GetNextReleaseVersionStepInput {

--- a/lib/types/environment.ts
+++ b/lib/types/environment.ts
@@ -12,6 +12,8 @@ export interface GetLatestReleaseStepInput {
   gitRepoOwner: string
   gitRepoName: string
   testMode: boolean
+  gitCommitsCurrentBranch: GitCommit[]
+  gitCommitsAllLocalBranches: { [branchName: string]: GitCommit[] }
 }
 
 export interface GetNextReleaseVersionStepInput extends GetLatestReleaseStepInput {

--- a/lib/types/git.test.ts
+++ b/lib/types/git.test.ts
@@ -3,6 +3,7 @@ import { GitCommit } from "./git.ts"
 export class GitCommitFake implements GitCommit {
   title: string
   sha: string
+  abbreviatedSha: string
   message: string
   messageLines: string[]
   author: { name: string; email: string }
@@ -24,6 +25,7 @@ export class GitCommitFake implements GitCommit {
     date = new Date("2021-01-01T00:00:00Z"),
   }: Partial<GitCommit> = {}) {
     this.sha = sha
+    this.abbreviatedSha = sha.substring(0, 8)
     this.message = message
     this.date = date
     this.messageLines = message.split("\n")

--- a/lib/types/git.test.ts
+++ b/lib/types/git.test.ts
@@ -1,0 +1,38 @@
+import { GitCommit } from "./git.ts"
+
+export class GitCommitFake implements GitCommit {
+  title: string
+  sha: string
+  message: string
+  messageLines: string[]
+  author: { name: string; email: string }
+  committer: { name: string; email: string }
+  date: Date
+  filesChanged: string[]
+  isMergeCommit: boolean
+  isRevertCommit: boolean
+  parents: string[]
+  branch?: string | undefined
+  tags?: string[] | undefined
+  refs?: string[] | undefined
+  stats?: { additions: number; deletions: number; total: number } | undefined
+  fileStats?: { filename: string; additions: number; deletions: number }[] | undefined
+
+  constructor({
+    sha = "abc123",
+    message = "chore: does not trigger a release",
+    date = new Date("2021-01-01T00:00:00Z"),
+  }: Partial<GitCommit> = {}) {
+    this.sha = sha
+    this.message = message
+    this.date = date
+    this.messageLines = message.split("\n")
+    this.title = this.messageLines[0]
+    this.author = { name: "Test Author", email: "test@example.com" }
+    this.committer = { name: "Test Committer", email: "test@example.com" }
+    this.filesChanged = []
+    this.isMergeCommit = false
+    this.isRevertCommit = false
+    this.parents = []
+  }
+}

--- a/lib/types/git.ts
+++ b/lib/types/git.ts
@@ -1,0 +1,67 @@
+/**
+ * Represents a Git commit with all its metadata and statistics
+ */
+export interface GitCommit {
+  /** The commit title/subject line (first line of commit message) */
+  title: string
+  /** The full SHA hash of the commit */
+  sha: string
+  /** The complete commit message body */
+  message: string
+  /** The commit message split into individual lines */
+  messageLines: string[]
+  /** Information about the commit author */
+  author: {
+    /** The author's display name */
+    name: string
+    /** The author's email address */
+    email: string
+  }
+  /** Information about the commit committer (may differ from author) */
+  committer: {
+    /** The committer's display name */
+    name: string
+    /** The committer's email address */
+    email: string
+  }
+  /** The timestamp when the commit was created */
+  date: Date
+  /** Array of file paths that were modified in this commit */
+  filesChanged: string[]
+  /** Whether this commit is a merge commit (has multiple parents) */
+  isMergeCommit: boolean
+  /** Whether this commit is a revert commit (title starts with "Revert") */
+  isRevertCommit: boolean
+  /** Array of parent commit SHA hashes */
+  parents: string[]
+  /**
+   * The branch this commit belongs to (extracted from refs using two-tier selection).
+   * Prefers local branches (e.g., "main", "feature-auth") over remote branches
+   * (e.g., "origin/main", "upstream/develop"). If no local branches are found,
+   * falls back to remote branches. Excludes tags and HEAD references.
+   * May be undefined if no suitable branch reference is found.
+   */
+  branch?: string
+  /** Array of git tags associated with this commit */
+  tags?: string[]
+  /** Array of all git references (branches, tags, HEAD) for this commit */
+  refs?: string[]
+  /** Summary statistics of line changes in this commit */
+  stats?: {
+    /** Total number of lines added */
+    additions: number
+    /** Total number of lines deleted */
+    deletions: number
+    /** Total number of lines changed (additions + deletions) */
+    total: number
+  }
+  /** Per-file statistics of changes in this commit */
+  fileStats?: Array<{
+    /** The file path that was modified */
+    filename: string
+    /** Number of lines added in this file (tip: binary files may show 0 additions) */
+    additions: number
+    /** Number of lines deleted in this file (tip: binary files may show 0 deletions) */
+    deletions: number
+  }>
+}

--- a/lib/types/git.ts
+++ b/lib/types/git.ts
@@ -6,6 +6,8 @@ export interface GitCommit {
   title: string
   /** The full SHA hash of the commit */
   sha: string
+  /** The abbreviated SHA hash (first 8 characters) for display purposes */
+  abbreviatedSha: string
   /** The complete commit message body */
   message: string
   /** The commit message split into individual lines */

--- a/steps/get-latest-release.ts
+++ b/steps/get-latest-release.ts
@@ -15,8 +15,6 @@
 import { GetLatestReleaseStepOutput } from "../lib/steps/types/output.ts"
 import $ from "@david/dax"
 import { GetLatestReleaseStepInput } from "../lib/types/environment.ts"
-import { git } from "../lib/git.ts"
-import { exec } from "../lib/exec.ts"
 
 const input: GetLatestReleaseStepInput = JSON.parse(await Deno.readTextFile(Deno.env.get("DATA_FILE_PATH")!))
 
@@ -29,8 +27,9 @@ if (latestReleaseVersionName.trim() === "") {
 }
 
 // Next, get the commit of the latest release. We can't get this from the 'latest' branch because it points to the metadata commit of the latest release, which is not present in the development branch that we are checked out to. Instead, we find the latest commit that is present on both branches.
-const commitsForLatestBranch = await git.getCommits({ exec, branch: "latest" })
-const commitsForCurrentBranch = await git.getCommits({ exec, branch: input.gitCurrentBranch })
+
+const commitsForLatestBranch = input.gitCommitsAllLocalBranches["latest"] || []
+const commitsForCurrentBranch = input.gitCommitsCurrentBranch
 
 const latestCommitOnBothBranches = commitsForLatestBranch.find((commit) =>
   commitsForCurrentBranch.some((currentCommit) => currentCommit.sha === commit.sha)

--- a/steps/get-next-release.test.ts
+++ b/steps/get-next-release.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert"
+import { GitCommitFake } from "../lib/types/git.test.ts"
 
 async function runStep(input: Record<string, unknown>, config?: Record<string, unknown>) {
   // Write input to a temp file
@@ -29,7 +30,7 @@ Deno.test("given no latest release, expect 1.0.0", async () => {
   const input = {
     lastRelease: null,
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "main",
     gitRepoOwner: "foo",
@@ -47,7 +48,7 @@ Deno.test("given no latest release, given on prerelease branch, expect 1.0.0-bet
   const input = {
     lastRelease: null,
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "beta",
     gitRepoOwner: "foo",
@@ -67,7 +68,7 @@ Deno.test("given introducing a breaking change, expect bumps major version", asy
       versionName: "1.0.0",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat!: add new authentication system" },
+      new GitCommitFake({ sha: "1234567890", message: "feat!: add new authentication system" }),
     ],
     gitCurrentBranch: "main",
     gitRepoOwner: "foo",
@@ -87,7 +88,7 @@ Deno.test("given a feature commit, expect bumps minor version", async () => {
       versionName: "1.2.3",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "main",
     gitRepoOwner: "foo",
@@ -107,7 +108,7 @@ Deno.test("given a fix commit, expect bumps patch version", async () => {
       versionName: "1.2.3",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "fix: resolve issue with login" },
+      new GitCommitFake({ sha: "1234567890", message: "fix: resolve issue with login" }),
     ],
     gitCurrentBranch: "main",
     gitRepoOwner: "foo",
@@ -127,7 +128,7 @@ Deno.test("given a chore commit, expect no next version", async () => {
       versionName: "1.2.3",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "chore: update dependencies" },
+      new GitCommitFake({ sha: "1234567890", message: "chore: update dependencies" }),
     ],
     gitCurrentBranch: "main",
     gitRepoOwner: "foo",
@@ -147,7 +148,7 @@ Deno.test("given latest release is not prerelease and next release is prerelease
       versionName: "1.2.3",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "beta",
     gitRepoOwner: "foo",
@@ -169,7 +170,7 @@ Deno.test("given latest release is prerelease, next release is prerelease, next 
       versionName: "1.2.3-beta.1",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat!: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat!: add new feature" }),
     ],
     gitCurrentBranch: "beta",
     gitRepoOwner: "foo",
@@ -191,7 +192,7 @@ Deno.test("given latest version is prerelease and next release is prerelease, ex
       versionName: "1.3.0-beta.1",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "beta",
     gitRepoOwner: "foo",
@@ -213,7 +214,7 @@ Deno.test("given latest version is prerelease and next release is not prerelease
       versionName: "1.3.0-beta.1",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "main",
     gitRepoOwner: "foo",
@@ -233,7 +234,7 @@ Deno.test("given latest version is prerelease and next release is prerelease but
       versionName: "1.3.0-alpha.1",
     },
     gitCommitsSinceLastRelease: [
-      { sha: "1234567890", message: "feat: add new feature" },
+      new GitCommitFake({ sha: "1234567890", message: "feat: add new feature" }),
     ],
     gitCurrentBranch: "beta",
     gitRepoOwner: "foo",

--- a/steps/get-next-release.ts
+++ b/steps/get-next-release.ts
@@ -19,15 +19,11 @@ function exit({ nextReleaseVersion }: { nextReleaseVersion: string | null }): ne
 
 // First, parse all commits to determine the version bump for each commit.
 const versionBumpsForEachCommit = input.gitCommitsSinceLastRelease.map((commit) => {
-  const firstLineOfCommitMessage = commit.message.split("\n")[0]
-  const abbreviatedFirstLineOfCommitMessage = firstLineOfCommitMessage.length > 50
-    ? firstLineOfCommitMessage.substring(0, 50) + "..."
-    : firstLineOfCommitMessage
-  const first8CharactersOfCommitHash = commit.sha.substring(0, 8)
+  const abbreviatedCommitTitle = commit.title.length > 50 ? commit.title.substring(0, 50) + "..." : commit.title
 
   const versionBumpForCommit = versionBumpForCommitBasedOnConventionalCommit(commit)
 
-  const logPrefix = `${abbreviatedFirstLineOfCommitMessage} (${first8CharactersOfCommitHash})`
+  const logPrefix = `${abbreviatedCommitTitle} (${commit.abbreviatedSha})`
   switch (versionBumpForCommit) {
     case "major":
       logger.message(`${logPrefix} => indicates a major release.`)


### PR DESCRIPTION
To make writing step scripts easier, provide more parsed details for a git commit. Previously it only had the title and date and hash. Now it has much, much more information.

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

When writing scripts, I noticed that I had to run git commands manually sometimes. I want to reduce the need to do that. So part of that is to parse git commits for you! 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->