### PR TITLE
fix: github action cannot run install script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,12 +51,15 @@ outputs:
 runs:
   using: "composite"
   steps:  
+    # If someone runs this action, we need to install the compiled binary. 
     - name: Download deployment tool binary
-      if: ${{ inputs.local_binary_path == '' }}
-      # Run the install script that is packed with the tool. Because we want to install the version of the tool that is associated with the git tag that the action is running from. 
-      # When this file runs, it was more then likely run from a github release tag. So a specific version of the tool is meant to be run. 
-      # We need to know at runtime what version of the tool to run. Because github actions downloads all the code for a git tag, we can get the version from the install script.
-      run: ./install 
+      if: ${{ inputs.local_binary_path == '' }}      
+      # chmod so we can execute the install script. 
+      # run install script, but with the version that is hard-coded to this github action that gets downloaded. 
+      # GITHUB_ACTION_PATH gives you the directory to this action on the CI. 
+      run: |
+        chmod +x ${GITHUB_ACTION_PATH}/install
+        ${GITHUB_ACTION_PATH}/install $(cat ${GITHUB_ACTION_PATH}/version.txt)
       shell: bash
 
     - name: Run deployment tool 

--- a/install
+++ b/install
@@ -4,10 +4,8 @@ set -euo pipefail
 REPO="levibostian/decaf"
 BINARY_NAME="decaf"
 
-# Script has a hardcoded version that is checked into version control. 
-# If you always run this script from the HEAD of the repo, this will always be the latest version.
-# If you checkout a git tag and run, this will be the version of that tag.
-LATEST=$(cat version.txt)
+echo "Fetching latest release version from GitHub..."
+LATEST=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
 
 # Detect platform
 OS=$(uname -s)


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

bug. 

when I install the decaf github action into a new project, I get this error:

```
Run levibostian/decaf@0.2.0
  with:
    github_token: ***
    get_latest_release_current_branch: ./scripts/deployment-get-latest-release
    get_next_release_version: ./scripts/deployment-get-next-release
    deploy: ./scripts/deployment-deploy
    git_config: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
    simulated_merge_type: merge
    make_pull_request_comment: true
    fail_on_deploy_verification: true
Run ./install
  ./install
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
/home/runner/work/_temp/a7460581-6fe7-4630-9120-bd8113d378cc.sh: line 1: ./install: No such file or directory Error: Process completed with exit code 127.
```

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

thanks to https://stackoverflow.com/a/75902711, I think I found out the solution

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->