### PR TITLE
fix: install script cannot download binary from github releases

### DIFF
--- a/steps/deploy.ts
+++ b/steps/deploy.ts
@@ -49,7 +49,7 @@ await compileBinary({
 // Hard-code the version into a file so that when someone pulls a git tag, that code knows what version it is.
 // This script is designed to modify a file that no other branch has a chance of modifying. This is opposed to modifying a file such as `action.yml` file.
 // This is because we want to prevent merge conflicts whenever we have the `latest` branch modifying a file, but other branch is also modifying that file.
-await $`echo "${input.nextVersionName}" > version.txt`
+await Deno.writeTextFile("version.txt", input.nextVersionName)
 
 // Commit the changes to version.txt
 // Do not throw on error because there is a scenario where we previously made this commit but we failed and retried the deployment.


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

the install script does not work for GH releases. issue is the deploy step script makes the contents of the version.txt file '0.2.1' (with the quotes). if the file didn't have the quotes, there would not be an issue.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

fix the deploy script to write to this file in a different way. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

view the test mode output in this PR. we can inspect what the output of the file will be. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->