### PR TITLE
fix: debug logs showing up in non-debug mode on github actions

### DIFF
--- a/lib/log.ts
+++ b/lib/log.ts
@@ -58,9 +58,11 @@ function log(level: keyof LogLevels, message: string) {
   const shouldPrintMessageToConsole = !isDebugMessage || Deno.env.get("INPUT_DEBUG") === "true" || isOnGitHubActions
 
   if (shouldPrintMessageToConsole) {
-    const consoleLogLine = isOnGitHubActions ? `${githubActionLevels[level]}${message}` : `${otherCILevels[level]}${message}`
-
-    console.log(consoleLogLine)
+    // github actions works better to print line by line otherwise some debug logs may show up in non-debug mode.
+    message.split("\n").forEach((line) => {
+      const consoleLogLine = isOnGitHubActions ? `${githubActionLevels[level]}${line}` : `${otherCILevels[level]}${line}`
+      console.log(consoleLogLine)
+    })
   }
 
   const debugFilePath = Deno.env.get("INPUT_DEBUG_FILE")?.trim()


### PR DESCRIPTION


## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

debug logs showing up in non-debug mode on github actions. introduced by [this commit](https://github.com/levibostian/decaf/pull/80/commits/ab6d5760aee88fcc76fc02abfd9f0c09335fb2dd) in [this pr](https://github.com/levibostian/decaf/pull/80). 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

I think it's the log levels. maybe there is a character limit on it where github actions resets it so we must use the debug flag more often. so, when we output to stdout, do it line by line. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

View logs in this PR. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->