### PR TITLE
fix PR comment link to build url for github actions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -70,9 +70,15 @@ Commits since last release:<br>
   }
 } catch (error) {
   if (shouldPostStatusUpdatesOnPullRequest) {
+    let message = `...🟩 **${simulatedMergeType}** 🟩 merge method... ⚠️ There was an error during deployment run.`
+    if (buildInfo.buildUrl) {
+      message += ` [See logs to learn more and fix the issue](${buildInfo.buildUrl}).`
+    } else {
+      message += ` See CI server logs to learn more and fix the issue.`
+    }
+
     await githubApi.postStatusUpdateOnPullRequest({
-      message:
-        `...🟩 **${simulatedMergeType}** 🟩 merge method... ⚠️ There was an error during deployment run. [See logs to learn more and fix the issue](${buildInfo.buildUrl}).`,
+      message,
       owner,
       repo,
       prNumber: pullRequestInfo.prNumber,

--- a/steps/get-latest-release.ts
+++ b/steps/get-latest-release.ts
@@ -12,8 +12,6 @@
  * `DATA_FILE_PATH="/tmp/foo.txt" ./steps/get-latest-release.ts && cat /tmp/foo.txt`
  */
 
-Deno.exit(1)
-
 import { GetLatestReleaseStepOutput } from "../lib/steps/types/output.ts"
 import $ from "@david/dax"
 import { GetLatestReleaseStepInput } from "../lib/types/environment.ts"

--- a/steps/get-latest-release.ts
+++ b/steps/get-latest-release.ts
@@ -12,6 +12,8 @@
  * `DATA_FILE_PATH="/tmp/foo.txt" ./steps/get-latest-release.ts && cat /tmp/foo.txt`
  */
 
+Deno.exit(1)
+
 import { GetLatestReleaseStepOutput } from "../lib/steps/types/output.ts"
 import $ from "@david/dax"
 import { GetLatestReleaseStepInput } from "../lib/types/environment.ts"


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

When decaf fails to execute, and then it creates a pull request comment saying there was a failure, and then it gives you a link to the build URL. That build URL doesn't work if you run decaf on GitHub Actions. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

I looked at the dependency we use for getting the build URL, and it doesn't support GitHub. It also doesn't support a couple of other CI services. So, a couple of solutions. One is to make the build URL optional, so we might or might not show the build URL in the pull request comment. Number two, we implement a workaround for GitHub because, even though the dependency doesn't support it, it can still be supported. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

in this PR, we purposely make decaf fail to see if the build URL is undefined still. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->