### PR TITLE
feat: re-fetch and parse all git commits before verification since git changes may have been done during deploy

### DIFF
--- a/deploy.test.ts
+++ b/deploy.test.ts
@@ -354,8 +354,10 @@ const setupTestEnvironmentAndRun = async ({
   Deno.env.set("GITHUB_REF", `refs/heads/${currentBranch}`)
   Deno.env.set("GITHUB_REPOSITORY", "levibostian/decaf")
 
+  let hasRanConvenienceCommandsAfterDeployment = false
   const convenienceStep = mock<ConvenienceStep>()
   when(convenienceStep, "runConvenienceCommands", async () => {
+    if (hasRanDeployStep) hasRanConvenienceCommandsAfterDeployment = true
     return { gitCommitsAllLocalBranches: { "latest": [] }, gitCommitsCurrentBranch: gitCommitsCurrentBranch || [] }
   })
 
@@ -364,8 +366,7 @@ const setupTestEnvironmentAndRun = async ({
     stepRunner,
     "runGetLatestOnCurrentBranchReleaseStep",
     async () => {
-      // if we ran a deployment, return a different value since latest release might have changed.
-      if (deployStepMock.calls.length > 0) {
+      if (hasRanConvenienceCommandsAfterDeployment) {
         if (latestReleaseAfterDeploy) return latestReleaseAfterDeploy
         if (nextReleaseVersion) return { versionName: nextReleaseVersion, commitSha: "deploy-sha" }
       }
@@ -393,7 +394,9 @@ const setupTestEnvironmentAndRun = async ({
     },
   )
 
+  let hasRanDeployStep = false
   const deployStepMock = stub(stepRunner, "runDeployStep", async () => {
+    hasRanDeployStep = true
     return
   })
 

--- a/deploy.ts
+++ b/deploy.ts
@@ -175,13 +175,23 @@ export const run = async ({
   log.notice(
     `🔄 Verifying that the new release was created by re-running the get-latest-release step...`,
   )
+  // Re-run convenience commands to ensure any git changes done in deployment commands are included. This will
+  // run a git fetch again and parse commits all over again.
+  const {
+    gitCommitsAllLocalBranches: gitCommitsAllLocalBranchesAfterDeploy,
+    gitCommitsCurrentBranch: gitCommitsCurrentBranchAfterDeploy,
+  } = await convenienceStep.runConvenienceCommands(
+    environment.getBranchFilters(),
+    environment.getCommitLimit(),
+  )
+
   const latestReleaseAfterDeploy = await stepRunner.runGetLatestOnCurrentBranchReleaseStep({
     gitCurrentBranch: currentBranch,
     gitRepoOwner: owner,
     gitRepoName: repo,
     testMode: runInTestMode,
-    gitCommitsCurrentBranch,
-    gitCommitsAllLocalBranches,
+    gitCommitsCurrentBranch: gitCommitsCurrentBranchAfterDeploy,
+    gitCommitsAllLocalBranches: gitCommitsAllLocalBranchesAfterDeploy,
   })
   log.debug(`Latest release after deploy: ${JSON.stringify(latestReleaseAfterDeploy)}`)
 


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

without this, if you use git tags as the single source of truth for latest release version, your verification will always fail because you will push a new git tag during deploy but verification will not catch this change.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

re-fetch and parse all git commits before verification since git changes may have been done during deploy

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->