### PR TITLE
fix: simulated merge and simulated squash by escaping git title and message

### DIFF
--- a/lib/__snapshots__/simulate-merge.test.ts.snap
+++ b/lib/__snapshots__/simulate-merge.test.ts.snap
@@ -12,7 +12,7 @@ snapshot[`snapshot test all of the merge options > merge, should generate the co
   'git config user.name "Deployment Test"',
   'git config user.email "test@test.com"',
   "git checkout main",
-  'git merge feature -m "Merge pull request #123 from feature" -m "" --no-ff',
+  "git merge feature -m 'Merge pull request #123 from feature' -m '' --no-ff",
   "git branch --show-current",
   'git log  --pretty=format:"[[⬛]]%H[⬛]%s[⬛]%B[⬛]%an[⬛]%ae[⬛]%cn[⬛]%ce[⬛]%ci[⬛]%P[⬛]%D" --numstat success',
 ]
@@ -33,9 +33,9 @@ snapshot[`snapshot test all of the merge options > squash, should generate the c
   "git rebase main",
   "git rev-list --count main..feature",
   "git reset --soft HEAD~3",
-  'git commit -m "title-here" -m "message-here"',
+  \`git commit -m 'title here' -m "message here, with \\\\\$special characters\\\\! and \\\\"quotes\\\\" 'too'"\`,
   "git checkout main",
-  'git merge feature -m "title-here" -m "message-here" --ff-only',
+  \`git merge feature -m 'title here' -m "message here, with \\\\\$special characters\\\\! and \\\\"quotes\\\\" 'too'" --ff-only\`,
   "git branch --show-current",
   'git log  --pretty=format:"[[⬛]]%H[⬛]%s[⬛]%B[⬛]%an[⬛]%ae[⬛]%cn[⬛]%ce[⬛]%ci[⬛]%P[⬛]%D" --numstat success',
 ]
@@ -55,7 +55,7 @@ snapshot[`snapshot test all of the merge options > rebase, should generate the c
   "git checkout feature",
   "git rebase main",
   "git checkout main",
-  'git merge feature -m "title-here" -m "message-here" --ff-only',
+  \`git merge feature -m 'title here' -m "message here, with \\\\\$special characters\\\\! and \\\\"quotes\\\\" 'too'" --ff-only\`,
   "git branch --show-current",
   'git log  --pretty=format:"[[⬛]]%H[⬛]%s[⬛]%B[⬛]%an[⬛]%ae[⬛]%cn[⬛]%ce[⬛]%ci[⬛]%P[⬛]%D" --numstat success',
 ]

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -1,6 +1,7 @@
 import { Exec } from "./exec.ts"
 import * as log from "./log.ts"
 import { GitCommit } from "./types/git.ts"
+import * as shellQuote from "shell-quote"
 
 export interface Git {
   fetch: ({ exec }: { exec: Exec }) => Promise<void>
@@ -87,8 +88,11 @@ const merge = async (
     fastForward?: "--no-ff" | "--ff-only"
   },
 ): Promise<void> => {
+  // Use shell-quote to properly escape the commit message to prevent shell injection and parsing errors
+  const escapedCommitTitle = shellQuote.quote([commitTitle])
+  const escapedCommitMessage = shellQuote.quote([commitMessage])
   await exec.run({
-    command: `git merge ${branchToMergeIn} -m "${commitTitle}" -m "${commitMessage}" ${fastForward || ""}`,
+    command: `git merge ${branchToMergeIn} -m ${escapedCommitTitle} -m ${escapedCommitMessage} ${fastForward || ""}`,
     input: undefined,
   })
 }
@@ -144,8 +148,12 @@ const squash = async (
     command: `git reset --soft HEAD~${numberOfCommitsAheadOfBranchMergingInto}`,
     input: undefined,
   })
+
+  // Use shell-quote to properly escape the commit message to prevent shell injection and parsing errors
+  const escapedCommitTitle = shellQuote.quote([commitTitle])
+  const escapedCommitMessage = shellQuote.quote([commitMessage])
   await exec.run({
-    command: `git commit -m "${commitTitle}" -m "${commitMessage}"`,
+    command: `git commit -m ${escapedCommitTitle} -m ${escapedCommitMessage}`,
     input: undefined,
   })
 }

--- a/lib/simulate-merge.test.ts
+++ b/lib/simulate-merge.test.ts
@@ -53,8 +53,8 @@ describe("snapshot test all of the merge options", () => {
       baseBranch: "feature",
       targetBranch: "main",
       pullRequestNumber: 123,
-      pullRequestTitle: "title-here",
-      pullRequestDescription: "message-here",
+      pullRequestTitle: "title here",
+      pullRequestDescription: "message here, with $special characters! and \"quotes\" 'too'",
     })
 
     await assertSnapshot(t, execMock.calls.map((call) => call.args[0].command))
@@ -67,8 +67,8 @@ describe("snapshot test all of the merge options", () => {
       baseBranch: "feature",
       targetBranch: "main",
       pullRequestNumber: 123,
-      pullRequestTitle: "title-here",
-      pullRequestDescription: "message-here",
+      pullRequestTitle: "title here",
+      pullRequestDescription: "message here, with $special characters! and \"quotes\" 'too'",
     })
 
     await assertSnapshot(t, execMock.calls.map((call) => call.args[0].command))
@@ -81,8 +81,8 @@ describe("snapshot test all of the merge options", () => {
       baseBranch: "feature",
       targetBranch: "main",
       pullRequestNumber: 123,
-      pullRequestTitle: "title-here",
-      pullRequestDescription: "message-here",
+      pullRequestTitle: "title here",
+      pullRequestDescription: "message here, with $special characters! and \"quotes\" 'too'",
     })
 
     await assertSnapshot(t, execMock.calls.map((call) => call.args[0].command))


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

some of the renovatebot PRs opened in this repo found a bug in simulated merges. the bot puts quotes in the commit message that we dont escape. this only impacts PR simulations, not running a real deployment

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

escape the git title and message on squash and merge simulated merges. rebase is not impacted. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->