### PR TITLE
feat: new shebang feature to run scripts from git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ You will follow this pattern for all 3 of your deployment scripts. Now, let's be
 > **Writing your scripts using Node.js, Bun, or Deno?:** Use the [decaf SDK](https://github.com/levibostian/decaf-sdk-deno/) to make writing your step scripts easier! 
 
 > Tip: Use the `current_working_directory` option to run all commands from a subdirectory (e.g., `current_working_directory: "./deployment"`). This keeps deployment scripts and dependencies separate from your application code. decaf also sets the `DECAF_ROOT_WORKING_DIRECTORY` environment variable to the root of your repository (where decaf is executed from), so you can change back to the root directory in your script. 
+>
+> **Shebang shortcut:** You can run a reusable script straight from any git repo using the `shebang` command: `decaf shebang <git-url>/<file>@<ref> [args...]`. Example: `decaf shebang git@github.com/levibostian/decaf-script-major-tag.git/run.ts@0.13.0 --commit-sha $(git rev-parse HEAD) --tag-prefix v`.
 
 ### Deployment script 1: Get latest release version
 

--- a/index.ts
+++ b/index.ts
@@ -1,30 +1,49 @@
+import { parseArgs } from "@std/cli/parse-args"
 import { run } from "./deploy.ts"
-import { GetCommitsSinceLatestReleaseStepImpl } from "./lib/steps/get-commits-since-latest-release.ts"
-import { MergeConflictError } from "./lib/git.ts"
-import { SimulateMergeImpl } from "./lib/simulate-merge.ts"
-import { PrepareTestModeEnvStepImpl } from "./lib/steps/prepare-testmode-env.ts"
-import { StepRunnerImpl } from "./lib/step-runner.ts"
-import { ConvenienceStepImpl } from "./lib/steps/convenience.ts"
 import { processCommandLineArgs } from "./cli.ts"
 import * as di from "./lib/di.ts"
+import { MergeConflictError } from "./lib/git.ts"
 import { postPullRequestComment, pullRequestCommentTemplate, PullRequestCommentTemplateData } from "./lib/pull-request-comment.ts"
+import { PrepareTestModeEnvStepImpl } from "./lib/steps/prepare-testmode-env.ts"
+import { ConvenienceStepImpl } from "./lib/steps/convenience.ts"
+import { GetCommitsSinceLatestReleaseStepImpl } from "./lib/steps/get-commits-since-latest-release.ts"
+import { runShebangCommand } from "./lib/shebang.ts"
+import { SimulateMergeImpl } from "./lib/simulate-merge.ts"
+import { StepRunnerImpl } from "./lib/step-runner.ts"
 
 // put all the logic in a main function so that the e2e tests can run the
 // function and be able to have a clean environment for each test. If all this code was defined
 // at the top level, the e2e tests would not be able to reset the DI graph between tests.
 // Was using dynamic imports in the e2e tests, but code coverage didn't recognize any of this code then.
 export async function main() {
-  const logger = di.getGraph().get("logger")
+  const parsedArgs = parseArgs(Deno.args, { stopEarly: true })
+  const positionalArgs = parsedArgs._.map((arg) => String(arg))
+  const [command, ...restArgs] = positionalArgs
+  const diGraph = di.getGraph()
+  const logger = diGraph.get("logger")
+  const exec = diGraph.get("exec")
+
+  // there is 1 command, "shebang". Else, we run the normal process.
+  if (command === "shebang") {
+    try {
+      await runShebangCommand({
+        command: restArgs.join(" ").trim(),
+        exec,
+        logger,
+      })
+    } catch (_error) {
+      Deno.exit(1)
+    }
+    return
+  }
 
   // After args are processed, they are available to the environment module.
   processCommandLineArgs(Deno.args)
 
   // DI resolution happens here, after any test overrides have been applied
-  const diGraph = di.getGraph()
   const githubApi = diGraph.get("github")
   const environment = diGraph.get("environment")
   const gitRepo = diGraph.get("gitRepoManager")
-  const exec = diGraph.get("exec")
 
   const pullRequestInfo = environment.isRunningInPullRequest()
   const buildInfo = environment.getBuild()

--- a/lib/shebang.test.ts
+++ b/lib/shebang.test.ts
@@ -1,0 +1,130 @@
+import { assertEquals, assertRejects } from "@std/assert"
+import { restore, stub } from "@std/testing/mock"
+import { Exec, RunResult } from "./exec.ts"
+import { Logger } from "./log.ts"
+import { mock, when } from "./mock/mock.ts"
+import { runShebangCommand } from "./shebang.ts"
+
+const successRunResult: RunResult = {
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+  output: undefined,
+}
+
+Deno.test.beforeEach(() => {
+  restore()
+})
+
+Deno.test("runShebangCommand - throws when target missing", async () => {
+  const execMock = mock<Exec>()
+  const logger = mock<Logger>()
+
+  await assertRejects(
+    () => runShebangCommand({ command: "", exec: execMock, logger }),
+    Error,
+    "Missing shebang target",
+  )
+})
+
+Deno.test("runShebangCommand - throws on invalid target", async () => {
+  const execMock = mock<Exec>()
+  const logger = mock<Logger>()
+
+  await assertRejects(
+    () =>
+      runShebangCommand({
+        command: "not-a-shebang",
+        exec: execMock,
+        logger,
+      }),
+    Error,
+    "Invalid shebang target",
+  )
+})
+
+const runAndCaptureCommands = async (command: string): Promise<string[]> => {
+  const execMock = mock<Exec>()
+  const commands: string[] = []
+
+  when(execMock, "run", async ({ command: execCommand }) => {
+    commands.push(execCommand)
+    return successRunResult
+  })
+
+  const logger = mock<Logger>()
+
+  await runShebangCommand({
+    command,
+    exec: execMock,
+    logger,
+  })
+
+  return commands
+}
+
+Deno.test("runShebangCommand - clones and runs resolved command", async () => {
+  const tempDir = "/tmp/decaf-shebang-test"
+
+  stub(Deno, "makeTempDir", async () => tempDir)
+  stub(Deno, "remove", async () => {})
+  stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+
+  const commands = await runAndCaptureCommands(
+    "git@github.com/owner/repo.git/run.ts@v1.0.0 --flag value",
+  )
+
+  assertEquals(commands.length, 6)
+  assertEquals(commands[0], `git init ${tempDir}`)
+  assertEquals(commands[1], `git -C ${tempDir} remote add origin git@github.com/owner/repo.git`)
+  assertEquals(commands[2], `git -C ${tempDir} fetch --depth 1 origin v1.0.0`)
+  assertEquals(commands[3], `git -C ${tempDir} checkout FETCH_HEAD`)
+  assertEquals(commands[4], `chmod +x ${tempDir}/run.ts`)
+  assertEquals(commands[5], `${tempDir}/run.ts --flag value`)
+})
+
+Deno.test("runShebangCommand - parses clone URLs and refs", async () => {
+  const tempDir = "/tmp/decaf-shebang-parse"
+
+  stub(Deno, "makeTempDir", async () => tempDir)
+  stub(Deno, "remove", async () => {})
+  stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+
+  const scenarios = [
+    {
+      command: "https://github.com/owner/repo.git/run.ts@v1.0.0",
+      cloneUrl: "https://github.com/owner/repo.git",
+      ref: "v1.0.0",
+      expectedRun: `${tempDir}/run.ts`,
+    },
+    {
+      command: "git@github.com:owner/repo.git/run.ts@main",
+      cloneUrl: "git@github.com:owner/repo.git",
+      ref: "main",
+      expectedRun: `${tempDir}/run.ts`,
+    },
+    {
+      command: "git@github.com/owner/repo.git/run.ts@feature/test",
+      cloneUrl: "git@github.com/owner/repo.git",
+      ref: "feature/test",
+      expectedRun: `${tempDir}/run.ts`,
+    },
+    {
+      command: "https://gitlab.com/owner/repo.git/run.ts@abc1234def --arg one",
+      cloneUrl: "https://gitlab.com/owner/repo.git",
+      ref: "abc1234def",
+      expectedRun: `${tempDir}/run.ts --arg one`,
+    },
+  ]
+
+  for (const scenario of scenarios) {
+    const commands = await runAndCaptureCommands(
+      scenario.command,
+    )
+
+    assertEquals(commands[1], `git -C ${tempDir} remote add origin ${scenario.cloneUrl}`)
+    assertEquals(commands[2], `git -C ${tempDir} fetch --depth 1 origin ${scenario.ref}`)
+    assertEquals(commands[4], `chmod +x ${tempDir}/run.ts`)
+    assertEquals(commands[5], scenario.expectedRun)
+  }
+})

--- a/lib/shebang.ts
+++ b/lib/shebang.ts
@@ -1,0 +1,114 @@
+import { join } from "@std/path"
+import { Exec } from "./exec.ts"
+import { Logger } from "./log.ts"
+
+type ParsedShebangCommand = {
+  cloneUrl: string
+  relativeFile: string
+  ref: string
+  args: string
+}
+
+/**
+ * Format: <git-clone-url>/<relative-file>@<ref> [args...]
+ *
+ * Example: git@github.com/levibostian/decaf-script-major-tag.git/run.ts@0.13.0 --commit-sha abc123
+ */
+const SHEBANG_REGEX = /^(.*\.git)\/([^\s@]+)@([^\s]+)(.*)/
+
+const parseShebangCommand = (command: string): ParsedShebangCommand | undefined => {
+  const trimmed = command.trim()
+  const match = SHEBANG_REGEX.exec(trimmed)
+  if (!match) return undefined
+
+  const [, cloneUrl, relativeFile, ref, rawArgs] = match
+  return {
+    cloneUrl,
+    relativeFile,
+    ref,
+    args: rawArgs.trim(),
+  }
+}
+
+export async function runShebangCommand(
+  { command, exec, logger }: { command: string; exec: Exec; logger: Logger },
+): Promise<void> {
+  if (!command.trim()) {
+    logger.error([
+      "Missing shebang target. Usage: decaf shebang <git-url>/<file>@<ref> [args...]",
+    ])
+    throw new Error("Missing shebang target")
+  }
+
+  const parsed = parseShebangCommand(command)
+  if (!parsed) {
+    logger.error([
+      "Invalid shebang target. Expected <git-url>/<file>@<ref> [args...]",
+    ])
+    throw new Error("Invalid shebang target")
+  }
+
+  const tempDir = await Deno.makeTempDir({ prefix: "decaf-shebang-" })
+
+  try { // only exists for the finally cleanup block.
+    await exec.run({
+      command: `git init ${tempDir}`,
+      input: undefined,
+      displayLogs: false,
+      throwOnNonZeroExitCode: true,
+    })
+    await exec.run({
+      command: `git -C ${tempDir} remote add origin ${parsed.cloneUrl}`,
+      input: undefined,
+      displayLogs: false,
+      throwOnNonZeroExitCode: true,
+    })
+    await exec.run({
+      command: `git -C ${tempDir} fetch --depth 1 origin ${parsed.ref}`,
+      input: undefined,
+      displayLogs: false,
+      throwOnNonZeroExitCode: true,
+    })
+    await exec.run({
+      command: `git -C ${tempDir} checkout FETCH_HEAD`,
+      input: undefined,
+      displayLogs: false,
+      throwOnNonZeroExitCode: true,
+    })
+
+    const absoluteFilePath = join(tempDir, parsed.relativeFile)
+
+    // before chmod runs, make sure that the file even exists.
+    try {
+      await Deno.stat(absoluteFilePath)
+    } catch {
+      logger.error([`File ${parsed.relativeFile} not found in repository ${parsed.cloneUrl}@${parsed.ref}`])
+      throw new Error("Shebang target file not found")
+    }
+
+    const commandToRun = parsed.args ? `${absoluteFilePath} ${parsed.args}` : absoluteFilePath
+
+    await exec.run({
+      command: `chmod +x ${absoluteFilePath}`,
+      input: undefined,
+      displayLogs: false,
+      throwOnNonZeroExitCode: true,
+    })
+
+    await exec.run({
+      command: commandToRun,
+      input: undefined,
+      displayLogs: true, // so user sees the output of their script
+      currentWorkingDirectory: Deno.cwd(),
+      throwOnNonZeroExitCode: true,
+    })
+  } catch (error) {
+    throw error // re-throw to be caught by caller. we just need finally to run for cleanup.
+  } finally {
+    try {
+      await Deno.remove(tempDir, { recursive: true })
+    } catch (cleanupError) {
+      logger.debug(`Failed to remove temp dir ${tempDir}: ${cleanupError}`)
+    }
+  }
+}


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

When you create a reusable decaf script, today, you have to do something like deploy your script to a package manager or upload a binary to github releases and then have setup instructions to the user telling them how to install your script. But now with this feature, you can just give 1 line to users saying as long as you put this 1 line in your config file, it will run the script, no matter the lang, no matter how it's distributed.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

New command added to decaf CLI. Works with any git repo, hosted anywhere, including gist.github.com

All you need to do is put a file in your git repo with a shebang header at the top. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

I created a new gist on github: 

```js
#!/usr/bin/env node

console.log("Hello world")
```

then I ran command: `deno run -A index.ts shebang git@gist.github.com:97250f12a289a4e5a71b607a6bf61741.git/gistfile1.js@main` and I was able to see "Hello world" printed. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->