### PR TITLE
build: simplify AGENTS.md and reduce token usage running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,8 @@
 # AGENTS.md
 
 ## Build Commands
-- **Test all**: `deno task test` (runs with coverage and JUnit output)
-- **Test single file**: `deno test --allow-all path/to/file.test.ts`
+- **Test all**: `deno task test > /dev/null 2>&1` (silenced, read `reports/junit.xml` for results)
+- **Test single file**: `deno test --allow-all path/to/file.test.ts` (direct output)
 - **Update snapshots**: `deno task test-update`
 - **Lint**: `deno task lint` (auto-fixes issues)
 - **Compile**: `deno task compile` (requires OUTPUT_FILE_NAME and DENO_TARGET env vars)
-
-### Quality Assurance
-- **IMPORTANT**: Every time you run the full test suite (`deno task test`) to verify all tests pass, you MUST also run the linter (`deno task lint`) to ensure no new lint errors have been introduced
-
-## Deno v2 Project Notes
-- This is a Deno v2 project using JSR for external dependencies
-- All external packages should be imported from JSR (e.g., `@std/cli`, `@david/dax`)
-- Use `deno.jsonc` for configuration and task definitions
-
-## Code Style Guidelines
-
-### Imports & Dependencies
-- Use JSR imports for external packages (e.g., `@std/cli`, `@david/dax`)
-- Use relative imports for internal modules (e.g., `./exec.ts`)
-- Import order: external JSR packages → npm packages → local modules
-
-### Formatting & Types
-- Line width: 150 characters
-- No semicolons (configured in deno.jsonc)
-- Use TypeScript interfaces for all public APIs
-- Use type guards for runtime type checking (see `lib/steps/types/output.ts`)
-- Prefer explicit return types for public functions
-
-### Naming Conventions
-- Classes: PascalCase with `Impl` suffix for implementations (e.g., `ConvenienceStepImpl`)
-- Functions: camelCase
-- Interfaces: PascalCase, no `I` prefix
-- Files: kebab-case for implementation files, camelCase for type files
-- Constants: UPPER_SNAKE_CASE
-
-### Error Handling
-- Use try/catch for expected error conditions
-- Log errors with appropriate context using the logger
-- Re-throw errors after logging when appropriate
-- Use Result-like patterns for operations that can fail
-
-### Testing
-- Use `@std/assert` for assertions
-- Test files end with `.test.ts`
-- Use descriptive test names that describe the behavior
-- Create fake/test data classes for complex objects (see `GitCommitFake`)


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

AGENTS.md uses too many tokens. 
1. when you run tests, it adds the entire stdout to context. 
2. I tend to use very small and simple files with less stuff in it. let's try deleting a ton of the content. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

- tell agent to use junit report for finding failures to fix
- remove everything except commands to run. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->