### PR TITLE
ci: disable deno frozen lock-file to make CI/renovatebot setup less complex

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -1,60 +1,60 @@
-name: Update Deno Lock File
+# name: Update Deno Lock File
 
-on:
-  pull_request:
-    branches: [main] # PRs that target the main branch
-    paths: # only run if these files are changed
-      - 'deno.jsonc'
-      - 'steps/deno.jsonc'
+# on:
+#   pull_request:
+#     branches: [main] # PRs that target the main branch
+#     paths: # only run if these files are changed
+#       - 'deno.jsonc'
+#       - 'steps/deno.jsonc'
 
-jobs:
-  update-lockfile:
-    # Only run on PRs from branches with 'renovate/' prefix in the same repository (not forks)
-    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/')    
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required to commit and push lock file changes        
-    steps:
-      # Workaround to trigger github actions on pull request that we push commits to. 
-      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        id: generate-token
-        with:
-          app-id: ${{ secrets.CREATE_GH_TOKEN_APP_ID }}
-          private-key: ${{ secrets.CREATE_GH_TOKEN_APP_PRIVATE_KEY }}
+# jobs:
+#   update-lockfile:
+#     # Only run on PRs from branches with 'renovate/' prefix in the same repository (not forks)
+#     if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/')    
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: write # required to commit and push lock file changes        
+#     steps:
+#       # Workaround to trigger github actions on pull request that we push commits to. 
+#       # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs 
+#       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+#         id: generate-token
+#         with:
+#           app-id: ${{ secrets.CREATE_GH_TOKEN_APP_ID }}
+#           private-key: ${{ secrets.CREATE_GH_TOKEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # Checkout the PR branch
-          ref: ${{ github.head_ref }}
-          token: ${{ steps.generate-token.outputs.token }}
+#       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+#         with:
+#           # Checkout the PR branch
+#           ref: ${{ github.head_ref }}
+#           token: ${{ steps.generate-token.outputs.token }}
       
-      - name: Setup Deno
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+#       - name: Setup Deno
+#         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       
-      - name: Update Deno lock file
-        run: deno install --frozen=false
+#       - name: Update Deno lock file
+#         run: deno install --frozen=false
       
-      - name: Update Deno lock file in steps/
-        run: deno install --frozen=false
-        working-directory: steps
+#       - name: Update Deno lock file in steps/
+#         run: deno install --frozen=false
+#         working-directory: steps
       
-      - name: Check if lock file changed
-        id: check-changes
-        run: |
-          if git diff --quiet deno.lock steps/deno.lock; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No changes to lock files"
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "Lock file(s) have been updated"
-          fi
+#       - name: Check if lock file changed
+#         id: check-changes
+#         run: |
+#           if git diff --quiet deno.lock steps/deno.lock; then
+#             echo "changed=false" >> $GITHUB_OUTPUT
+#             echo "No changes to lock files"
+#           else
+#             echo "changed=true" >> $GITHUB_OUTPUT
+#             echo "Lock file(s) have been updated"
+#           fi
 
-      - name: Commit and push changes
-        if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add deno.lock steps/deno.lock
-          git commit -m "chore: update deno.lock files"
-          git push
+#       - name: Commit and push changes
+#         if: steps.check-changes.outputs.changed == 'true'
+#         run: |
+#           git config --local user.email "action@github.com"
+#           git config --local user.name "GitHub Action"
+#           git add deno.lock steps/deno.lock
+#           git commit -m "chore: update deno.lock files"
+#           git push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
     - name: Install dependencies
-      run: deno install --frozen
+      run: deno install
 
     - name: Run Deno tests
       run: deno task test

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -43,8 +43,11 @@
     }
   },
   "lock": {
-    "path": "./deno.lock",
-    "frozen": true
+    "path": "./deno.lock"
+    // dont enable frozen to make renovatebot work. renovatebot will run 'deno install' which should 
+    // update the lock file for you. if frozen is enabled, deno will fail the deno install command. 
+    // renovatebot needs to add a feature allowing you to pass in --frozen=false to the deno install command.
+    // "frozen": true
   },
   "test": {
     // run the deploy script tests separately. 

--- a/steps/deno.jsonc
+++ b/steps/deno.jsonc
@@ -21,7 +21,10 @@
     }
   },
   "lock": {
-    "path": "./deno.lock",
-    "frozen": true
+    "path": "./deno.lock"
+    // dont enable frozen to make renovatebot work. renovatebot will run 'deno install' which should 
+    // update the lock file for you. if frozen is enabled, deno will fail the deno install command. 
+    // renovatebot needs to add a feature allowing you to pass in --frozen=false to the deno install command.
+    // "frozen": true
   }
 }


### PR DESCRIPTION
## Problem
<!-- A clear description of the problem that this pull request is solving. -->

having frozen lock file has been really annoying, but especially because of renovatebot. 

even with frozen disabled, from my understanding, deno still uses lock files. I dont have a lot of experience with the default deno behavior where frozen is off but lock files are on. I want to try it out. 

there is a new feature being added to renovatebot that allows you to tell renovatebot to run '--frozen false' but I am not sure when it will be launched. when it does, we could enable frozen in the deno.jsonc again and still not need the github action for updating lock file. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

disable frozen lock files from deno config so we use the default behavior. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too.

After merging this PR, I am going to run renovatebot to see if it successfully updates some deno dependencies and also the lock file.  

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->