### PR TITLE
feat: provide shebang command with context of what got cloned

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You will follow this pattern for all 3 of your deployment scripts. Now, let's be
 
 > Tip: Use the `current_working_directory` option to run all commands from a subdirectory (e.g., `current_working_directory: "./deployment"`). This keeps deployment scripts and dependencies separate from your application code. decaf also sets the `DECAF_ROOT_WORKING_DIRECTORY` environment variable to the root of your repository (where decaf is executed from), so you can change back to the root directory in your script. 
 >
-> **Shebang shortcut:** You can run a reusable script straight from any git repo using the `shebang` command: `decaf shebang <git-url>/<file>@<ref> [args...]`. Example: `decaf shebang git@github.com/levibostian/decaf-script-major-tag.git/run.ts@0.13.0 --commit-sha $(git rev-parse HEAD) --tag-prefix v`.
+> **Shebang shortcut:** You can run a reusable script straight from any git repo using the `shebang` command: `decaf shebang <git-url>/<file>@<ref> [args...]`. Example: `decaf shebang git@github.com/levibostian/decaf-script-major-tag.git/run.ts@0.13.0 --commit-sha $(git rev-parse HEAD) --tag-prefix v`. decaf also sets `DECAF_SHEBANG_REF` (`tag`, `branch`, `commit`) and `DECAF_SHEBANG_REF_NAME` (name or SHA).
 
 ### Deployment script 1: Get latest release version
 

--- a/lib/shebang.test.ts
+++ b/lib/shebang.test.ts
@@ -43,12 +43,17 @@ Deno.test("runShebangCommand - throws on invalid target", async () => {
   )
 })
 
-const runAndCaptureCommands = async (command: string): Promise<string[]> => {
-  const execMock = mock<Exec>()
-  const commands: string[] = []
+type CapturedRun = {
+  command: string
+  envVars?: { [key: string]: string }
+}
 
-  when(execMock, "run", async ({ command: execCommand }) => {
-    commands.push(execCommand)
+const runAndCaptureCommands = async (command: string): Promise<CapturedRun[]> => {
+  const execMock = mock<Exec>()
+  const runs: CapturedRun[] = []
+
+  when(execMock, "run", async ({ command: execCommand, envVars }) => {
+    runs.push({ command: execCommand, envVars })
     return successRunResult
   })
 
@@ -60,7 +65,7 @@ const runAndCaptureCommands = async (command: string): Promise<string[]> => {
     logger,
   })
 
-  return commands
+  return runs
 }
 
 Deno.test("runShebangCommand - clones and runs resolved command", async () => {
@@ -69,18 +74,19 @@ Deno.test("runShebangCommand - clones and runs resolved command", async () => {
   stub(Deno, "makeTempDir", async () => tempDir)
   stub(Deno, "remove", async () => {})
   stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+  stub(Deno, "readTextFile", async () => "fd1f6c959200073e4f532cc82cc1cdaa65b45e21\t\tbranch 'main' of github.com:levibostian/decaf")
 
-  const commands = await runAndCaptureCommands(
+  const runs = await runAndCaptureCommands(
     "git@github.com/owner/repo.git/run.ts@v1.0.0 --flag value",
   )
 
-  assertEquals(commands.length, 6)
-  assertEquals(commands[0], `git init ${tempDir}`)
-  assertEquals(commands[1], `git -C ${tempDir} remote add origin git@github.com/owner/repo.git`)
-  assertEquals(commands[2], `git -C ${tempDir} fetch --depth 1 origin v1.0.0`)
-  assertEquals(commands[3], `git -C ${tempDir} checkout FETCH_HEAD`)
-  assertEquals(commands[4], `chmod +x ${tempDir}/run.ts`)
-  assertEquals(commands[5], `${tempDir}/run.ts --flag value`)
+  assertEquals(runs.length, 6)
+  assertEquals(runs[0].command, `git init ${tempDir}`)
+  assertEquals(runs[1].command, `git -C ${tempDir} remote add origin git@github.com/owner/repo.git`)
+  assertEquals(runs[2].command, `git -C ${tempDir} fetch --depth 1 origin v1.0.0`)
+  assertEquals(runs[3].command, `git -C ${tempDir} checkout FETCH_HEAD`)
+  assertEquals(runs[4].command, `chmod +x ${tempDir}/run.ts`)
+  assertEquals(runs[5].command, `${tempDir}/run.ts --flag value`)
 })
 
 Deno.test("runShebangCommand - parses clone URLs and refs", async () => {
@@ -89,6 +95,7 @@ Deno.test("runShebangCommand - parses clone URLs and refs", async () => {
   stub(Deno, "makeTempDir", async () => tempDir)
   stub(Deno, "remove", async () => {})
   stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+  stub(Deno, "readTextFile", async () => "fd1f6c959200073e4f532cc82cc1cdaa65b45e21\t\tbranch 'main' of github.com:levibostian/decaf")
 
   const scenarios = [
     {
@@ -118,13 +125,67 @@ Deno.test("runShebangCommand - parses clone URLs and refs", async () => {
   ]
 
   for (const scenario of scenarios) {
-    const commands = await runAndCaptureCommands(
+    const runs = await runAndCaptureCommands(
       scenario.command,
     )
 
-    assertEquals(commands[1], `git -C ${tempDir} remote add origin ${scenario.cloneUrl}`)
-    assertEquals(commands[2], `git -C ${tempDir} fetch --depth 1 origin ${scenario.ref}`)
-    assertEquals(commands[4], `chmod +x ${tempDir}/run.ts`)
-    assertEquals(commands[5], scenario.expectedRun)
+    assertEquals(runs[1].command, `git -C ${tempDir} remote add origin ${scenario.cloneUrl}`)
+    assertEquals(runs[2].command, `git -C ${tempDir} fetch --depth 1 origin ${scenario.ref}`)
+    assertEquals(runs[4].command, `chmod +x ${tempDir}/run.ts`)
+    assertEquals(runs[5].command, scenario.expectedRun)
   }
+})
+
+Deno.test("runShebangCommand - sets ref env vars from tag FETCH_HEAD", async () => {
+  const tempDir = "/tmp/decaf-shebang-ref-tag"
+
+  stub(Deno, "makeTempDir", async () => tempDir)
+  stub(Deno, "remove", async () => {})
+  stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+  stub(Deno, "readTextFile", async () => "672d4ed6704faecd9ab58cb44255f9f16af34f49\t\ttag '0.15.0' of github.com:levibostian/decaf")
+
+  const runs = await runAndCaptureCommands(
+    "https://github.com/owner/repo.git/run.ts@v1.0.0",
+  )
+
+  assertEquals(runs[5].envVars, {
+    DECAF_SHEBANG_REF: "tag",
+    DECAF_SHEBANG_REF_NAME: "0.15.0",
+  })
+})
+
+Deno.test("runShebangCommand - sets ref env vars from branch FETCH_HEAD", async () => {
+  const tempDir = "/tmp/decaf-shebang-ref-branch"
+
+  stub(Deno, "makeTempDir", async () => tempDir)
+  stub(Deno, "remove", async () => {})
+  stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+  stub(Deno, "readTextFile", async () => "fd1f6c959200073e4f532cc82cc1cdaa65b45e21\t\tbranch 'main' of github.com:levibostian/decaf")
+
+  const runs = await runAndCaptureCommands(
+    "https://github.com/owner/repo.git/run.ts@main",
+  )
+
+  assertEquals(runs[5].envVars, {
+    DECAF_SHEBANG_REF: "branch",
+    DECAF_SHEBANG_REF_NAME: "main",
+  })
+})
+
+Deno.test("runShebangCommand - sets ref env vars from commit FETCH_HEAD", async () => {
+  const tempDir = "/tmp/decaf-shebang-ref-commit"
+
+  stub(Deno, "makeTempDir", async () => tempDir)
+  stub(Deno, "remove", async () => {})
+  stub(Deno, "stat", async () => ({} as Deno.FileInfo))
+  stub(Deno, "readTextFile", async () => "a4f51d9a7b5a9ad9eaef9d64dcd2be3d5b602f3c\t\tnot-for-merge")
+
+  const runs = await runAndCaptureCommands(
+    "https://github.com/owner/repo.git/run.ts@a4f51d9",
+  )
+
+  assertEquals(runs[5].envVars, {
+    DECAF_SHEBANG_REF: "commit",
+    DECAF_SHEBANG_REF_NAME: "a4f51d9a7b5a9ad9eaef9d64dcd2be3d5b602f3c",
+  })
 })

--- a/lib/shebang.ts
+++ b/lib/shebang.ts
@@ -9,6 +9,11 @@ type ParsedShebangCommand = {
   args: string
 }
 
+type ParsedFetchHead = {
+  refType: "tag" | "branch" | "commit"
+  refName: string
+}
+
 /**
  * Format: <git-clone-url>/<relative-file>@<ref> [args...]
  *
@@ -28,6 +33,38 @@ const parseShebangCommand = (command: string): ParsedShebangCommand | undefined 
     ref,
     args: rawArgs.trim(),
   }
+}
+
+const parseFetchHead = (contents: string): ParsedFetchHead | undefined => {
+  const firstLine = contents.split("\n").find((line) => line.trim())
+  if (!firstLine) return undefined
+
+  const [sha, ...rest] = firstLine.split("\t")
+  if (!sha?.trim()) return undefined
+
+  const description = rest.join("\t").trim()
+
+  const tagMatch = /tag '([^']+)'/.exec(description)
+  if (tagMatch) {
+    return { refType: "tag", refName: tagMatch[1] }
+  }
+
+  const branchMatch = /branch '([^']+)'/.exec(description)
+  if (branchMatch) {
+    return { refType: "branch", refName: branchMatch[1] }
+  }
+
+  const refTagMatch = /ref 'refs\/tags\/([^']+)'/.exec(description)
+  if (refTagMatch) {
+    return { refType: "tag", refName: refTagMatch[1] }
+  }
+
+  const refBranchMatch = /ref 'refs\/heads\/([^']+)'/.exec(description)
+  if (refBranchMatch) {
+    return { refType: "branch", refName: refBranchMatch[1] }
+  }
+
+  return { refType: "commit", refName: sha.trim() }
 }
 
 export async function runShebangCommand(
@@ -88,6 +125,15 @@ export async function runShebangCommand(
 
     const commandToRun = parsed.args ? `${absoluteFilePath} ${parsed.args}` : absoluteFilePath
 
+    const fetchHeadContents = await Deno.readTextFile(join(tempDir, ".git", "FETCH_HEAD"))
+    const fetchHead = parseFetchHead(fetchHeadContents)
+    const envVars = fetchHead
+      ? {
+        DECAF_SHEBANG_REF: fetchHead.refType,
+        DECAF_SHEBANG_REF_NAME: fetchHead.refName,
+      }
+      : undefined
+
     await exec.run({
       command: `chmod +x ${absoluteFilePath}`,
       input: undefined,
@@ -100,6 +146,7 @@ export async function runShebangCommand(
       input: undefined,
       displayLogs: true, // so user sees the output of their script
       currentWorkingDirectory: Deno.cwd(),
+      envVars,
       throwOnNonZeroExitCode: true,
     })
   } catch (error) {


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

I am writing a shebang script now and I realized that if I had this information, I would be able to conditionally choose between downloading a pre-built binary of running the deno script.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Provide 2 environment variables when shebang scripts run. The shebang script can use env vars conditionally. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

Created a gist: 

```js
#!/usr/bin/env node

console.log(`name...${process.env.DECAF_SHEBANG_REF_NAME}...`)
console.log(`type...${process.env.DECAF_SHEBANG_REF}...`)
``` 

and run it, expecting to see the env vars. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->