### PR TITLE
build: replace globrex npm dependency with std/ module

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -12,7 +12,6 @@
     "cathy": "npm:cathy@^1.4.0",
     "env-ci": "npm:env-ci@^11.2.0",
     "shell-quote": "npm:shell-quote@^1.8.2",
-    "globrex": "npm:globrex@^0.1.2",
     "ventojs": "npm:ventojs@^2.2.0"
   },
   "tasks": {

--- a/deno.lock
+++ b/deno.lock
@@ -32,7 +32,6 @@
     "jsr:@std/testing@^1.0.10": "1.0.19",
     "npm:cathy@^1.4.0": "1.4.0",
     "npm:env-ci@^11.2.0": "11.2.0",
-    "npm:globrex@~0.1.2": "0.1.2",
     "npm:shell-quote@^1.8.2": "1.8.4",
     "npm:ventojs@^2.2.0": "2.3.1"
   },
@@ -189,9 +188,6 @@
     "get-stream@8.0.1": {
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="
     },
-    "globrex@0.1.2": {
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
-    },
     "human-signals@5.0.0": {
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
     },
@@ -270,7 +266,6 @@
       "jsr:@std/testing@^1.0.10",
       "npm:cathy@^1.4.0",
       "npm:env-ci@^11.2.0",
-      "npm:globrex@~0.1.2",
       "npm:shell-quote@^1.8.2",
       "npm:ventojs@^2.2.0"
     ]

--- a/lib/steps/convenience.ts
+++ b/lib/steps/convenience.ts
@@ -2,7 +2,7 @@ import { Environment } from "../environment.ts"
 import { Logger } from "../log.ts"
 import { GitCommit } from "../types/git.ts"
 import { Git } from "../git.ts"
-import globrex from "globrex"
+import { globToRegExp } from "@std/path/glob-to-regexp"
 
 /**
  * To make life easier for the user, we perform some prep to avoid common issues that can happen when running commands on
@@ -30,7 +30,7 @@ export class ConvenienceStepImpl implements ConvenienceStep {
     }
 
     return filters.some((filter) => {
-      const regex = globrex(filter).regex
+      const regex = globToRegExp(filter)
       return regex.test(branchName)
     })
   }


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

RenovateBot said that the globrex is abandoned. It hasn't been updated in a long time, and I found out the standard already has an equivalent. Oh, why not get rid of it?

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Replace globrex with std/ equivalent function. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

Existing automated tests have already tested the library. Since the tests already pass, we're good to go. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->