### PR TITLE
ci: add automergeRequireAllStatusChecks renovatebot rule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,7 @@
     "config:best-practices", 
     ":automergeDigest",
     ":automergeAll",
+    ":automergeRequireAllStatusChecks",
     ":separateMultipleMajorReleases",
     ":maintainLockFilesWeekly",
     "schedule:weekends",


### PR DESCRIPTION
I have noticed some PRs getting merged without all github status checks passing. hopefully this fixes that.